### PR TITLE
Preserve perms for real and other fixes

### DIFF
--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -381,7 +381,7 @@ class PkgHistoryProcessor:
             {
                 "commit-id": commit.id,
                 "authorblurb": f"{commit.author.name} <{commit.author.email}>",
-                "timestamp": dt.datetime.utcfromtimestamp(commit.commit_time),
+                "timestamp": dt.datetime.fromtimestamp(commit.commit_time, dt.timezone.utc),
                 "commitlog": commit.message,
                 "epoch-version": commit_result["epoch-version"],
                 "release-complete": commit_result["release-complete"],
@@ -751,7 +751,7 @@ class PkgHistoryProcessor:
                     {
                         "commit-id": None,
                         "authorblurb": authorblurb,
-                        "timestamp": dt.datetime.utcnow(),
+                        "timestamp": dt.datetime.now(dt.timezone.utc),
                         "commitlog": "Uncommitted changes",
                         "epoch-version": epoch_version,
                         "release-complete": release_complete,

--- a/rpmautospec/subcommands/process_distgit.py
+++ b/rpmautospec/subcommands/process_distgit.py
@@ -69,7 +69,8 @@ def process_distgit(
     if target is None:
         target = processor.specfile
         specfile_mode = stat.S_IMODE(target.stat().st_mode)
-    elif isinstance(target, Path):
+
+    if not isinstance(target, Path):
         target = Path(target)
 
     if enable_caching:

--- a/tests/rpmautospec/test_pkg_history.py
+++ b/tests/rpmautospec/test_pkg_history.py
@@ -219,7 +219,7 @@ class TestPkgHistoryProcessor:
                 assert snippet in top_entry.format()
 
             cal = LocaleTextCalendar(firstweekday=0, locale="C.UTF-8")
-            commit_time = dt.datetime.utcfromtimestamp(head_commit.commit_time)
+            commit_time = dt.datetime.fromtimestamp(head_commit.commit_time, dt.timezone.utc)
             weekdayname = cal.formatweekday(day=commit_time.weekday(), width=3)
             monthname = cal.formatmonthname(
                 theyear=commit_time.year,


### PR DESCRIPTION
commit 4f1dbdda4cf1bfa2d174b7084a693d1e9dfb6f8e
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Nov 14 16:55:23 2023 +0100

    Ensure `target` is a Path object
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 36261dea1e4636e89e932ac09389b71cc0d594d0
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Nov 14 16:51:48 2023 +0100

    Don’t use deprecated UTC datetime methods
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 7d91753a6a289f3112d2ec1bb2819c240041895c
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Nov 14 16:53:45 2023 +0100

    Always preserve spec file permissions
    
    This will prefer the mode of the target file if it exists, otherwise
    that of the source file will be applied.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>