### PR TITLE
Support %include and %load directives better, and error out on unparseable spec file

### DIFF
--- a/rpmautospec/cli.py
+++ b/rpmautospec/cli.py
@@ -4,6 +4,7 @@ import locale
 import logging
 import sys
 
+from .exc import RpmautospecException
 from .subcommands import changelog, convert, process_distgit, release
 
 all_subcmds = (changelog, convert, process_distgit, release)
@@ -78,6 +79,13 @@ def get_arg_parser() -> CustomArgumentParser:
         help="Enable debugging output",
     )
 
+    parser.add_argument(
+        "--error-on-unparseable-spec",
+        help="Whether to throw an error if the current version of the spec file can’t be parsed",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+
     # parsers for sub-commands
 
     # ArgumentParser.add_subparsers() only accepts the `required` argument from Python 3.7 on.
@@ -121,4 +129,9 @@ def main():
 
     if args.subcommand:
         subcmd_module = subcmd_modules_by_name[args.subcommand]
-        sys.exit(subcmd_module.main(args))
+        try:
+            exit_code = subcmd_module.main(args)
+        except RpmautospecException as exc:
+            logging.error("%s", exc)
+            exit_code = 1
+        sys.exit(exit_code)

--- a/rpmautospec/cli.py
+++ b/rpmautospec/cli.py
@@ -53,25 +53,12 @@ def get_arg_parser() -> CustomArgumentParser:
 
     # global arguments
 
-    if hasattr(argparse, "BooleanOptionalAction"):
-        parser.add_argument(
-            "--pager",
-            action=argparse.BooleanOptionalAction,
-            help="Start a pager automatically",
-        )
-    else:  # pragma: no cover
-        # Python < 3.9
-        parser.add_argument(
-            "--pager",
-            action="store_true",
-            help="Start a pager automatically",
-        )
-        parser.add_argument(
-            "--no-pager",
-            dest="pager",
-            action="store_false",
-        )
-    parser.set_defaults(pager=True)
+    parser.add_argument(
+        "--pager",
+        action=argparse.BooleanOptionalAction,
+        help="Start a pager automatically",
+        default=True,
+    )
 
     log_level_group = parser.add_mutually_exclusive_group()
     log_level_group.add_argument(

--- a/rpmautospec/exc.py
+++ b/rpmautospec/exc.py
@@ -1,0 +1,6 @@
+class RpmautospecException(Exception):
+    """Base class for rpmautospec exceptions."""
+
+
+class SpecParseFailure(RpmautospecException):
+    """Failure parsing spec file."""

--- a/rpmautospec/subcommands/release.py
+++ b/rpmautospec/subcommands/release.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Union
 
+from ..exc import SpecParseFailure
 from ..pkg_history import PkgHistoryProcessor
 
 
@@ -42,33 +43,53 @@ def register_subcommand(subparsers):
 
 
 def calculate_release(
-    spec_or_path: Union[str, Path], *, complete_release: bool = True
+    spec_or_path: Union[str, Path],
+    *,
+    complete_release: bool = True,
+    error_on_unparseable_spec: bool,
 ) -> Union[str, int]:
     """Calculate release value (or number) of a package.
 
     :param spec_or_path: The spec file or directory it is located in.
-    :param complete_release: Whether to return the complete release (without
-                             dist tag) or just the number.
+    :param complete_release: Whether to return the complete release
+        (without dist tag) or just the number.
+    :param error_on_unparseable_spec: Whether or not failure at parsing
+        the current spec file should raise an exception.
     :return: the release value or number
     """
     processor = PkgHistoryProcessor(spec_or_path)
     result = processor.run(visitors=(processor.release_number_visitor,))
+    if error_on_unparseable_spec and result["epoch-version"] is None:
+        # If epoch-version is None, this indicates that the spec file couldn’t be parsed.
+        raise SpecParseFailure(f"Couldn’t parse spec file {processor.specfile.name}")
     return result["release-complete" if complete_release else "release-number"]
 
 
-def calculate_release_number(spec_or_path: Union[str, Path]) -> int:
+def calculate_release_number(
+    spec_or_path: Union[str, Path],
+    *,
+    error_on_unparseable_spec: bool,
+) -> int:
     """Calculate release number of a package.
 
     This number can be passed into the %autorelease macro as
     %_rpmautospec_release_number.
 
     :param spec_or_path: The spec file or directory it is located in.
+    :param error_on_unparseable_spec: Whether or not failure at parsing
+        the current spec file should raise an exception.
     :return: the release number
     """
-    return calculate_release(spec_or_path, complete_release=False)
+    return calculate_release(
+        spec_or_path, complete_release=False, error_on_unparseable_spec=error_on_unparseable_spec
+    )
 
 
 def main(args):
     """Main method."""
-    release = calculate_release(args.spec_or_path, complete_release=args.complete_release)
+    release = calculate_release(
+        args.spec_or_path,
+        complete_release=args.complete_release,
+        error_on_unparseable_spec=args.error_on_unparseable_spec,
+    )
     print("Calculated release number:", release)

--- a/tests/rpmautospec/subcommands/test_release.py
+++ b/tests/rpmautospec/subcommands/test_release.py
@@ -43,7 +43,10 @@ class TestRelease:
             expected_release = "11"
 
             if method_to_test == "calculate_release":
-                assert release.calculate_release(unpacked_repo_dir) == expected_release
+                assert (
+                    release.calculate_release(unpacked_repo_dir, error_on_unparseable_spec=True)
+                    == expected_release
+                )
             else:
                 args = mock.Mock()
                 args.spec_or_path = unpacked_repo_dir


### PR DESCRIPTION
- Previously, only lines with %include were filtered out prior to parsing. Now, if parsing fails, the complete worktree is checked out so that %include and %load have access to files in the repository.
- Previously, it would be hidden if the current revision spec file couldn’t be parsed. Now, this causes an error by default.

Fixes: #45