### PR TITLE
Cope better with non-ASCII encodings in spec files (plus change)

### DIFF
--- a/rpmautospec/subcommands/process_distgit.py
+++ b/rpmautospec/subcommands/process_distgit.py
@@ -101,7 +101,11 @@ def process_distgit(
 
     autorelease_number = result["release-number"]
 
-    with processor.specfile.open("r") as specfile, tempfile.NamedTemporaryFile("w") as tmp_specfile:
+    with processor.specfile.open(
+        "r", encoding="utf-8", errors="surrogateescape"
+    ) as specfile, tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", errors="surrogateescape"
+    ) as tmp_specfile:
         # Process the spec file into a temporary file...
         used_features = []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import locale as locale_mod
 from pathlib import Path
 
 import pygit2
@@ -35,6 +36,23 @@ def git_empty_config():
             pygit2.settings.search_path[level] = "/dev/null"
         except ValueError:
             pass
+
+
+@pytest.fixture(autouse=True)
+def locale():
+    """Ensure consistent locale and that modifications stay isolated."""
+    saved_locale_settings = {
+        category: locale_mod.getlocale(getattr(locale_mod, category))
+        for category in dir(locale_mod)
+        if category.startswith("LC_") and category != "LC_ALL"
+    }
+
+    locale_mod.setlocale(locale_mod.LC_ALL, "C.UTF-8")
+
+    yield locale_mod
+
+    for category, locale_settings in saved_locale_settings.items():
+        locale_mod.setlocale(getattr(locale_mod, category), locale_settings)
 
 
 @pytest.fixture

--- a/tests/rpmautospec/subcommands/test_process_distgit.py
+++ b/tests/rpmautospec/subcommands/test_process_distgit.py
@@ -481,11 +481,19 @@ def test_process_distgit(
             assert test_output == expected_output
 
 
-def test_main():
-    args = mock.Mock(spec_or_path="/boo")
-    with mock.patch.object(process_distgit, "process_distgit") as process_distgit_fn:
+def test_main(tmp_path):
+    output_spec_file = tmp_path / "test.spec"
+    unpacked_repo_dir, test_spec_file_path = gen_testrepo(tmp_path, "rawhide")
+
+    args = mock.Mock(spec_or_path=test_spec_file_path, target=output_spec_file)
+
+    with mock.patch.object(
+        process_distgit, "process_distgit", wraps=process_distgit.process_distgit
+    ) as process_distgit_fn:
         process_distgit.main(args)
 
     process_distgit_fn.assert_called_once_with(
-        Path("/boo"), args.target, error_on_unparseable_spec=args.error_on_unparseable_spec
+        test_spec_file_path,
+        output_spec_file,
+        error_on_unparseable_spec=args.error_on_unparseable_spec,
     )

--- a/tests/rpmautospec/test_pkg_history.py
+++ b/tests/rpmautospec/test_pkg_history.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import locale
 import os
 import re
 import stat
@@ -18,21 +17,6 @@ from rpmautospec import pkg_history
 def processor(repo):
     processor = pkg_history.PkgHistoryProcessor(repo.workdir)
     return processor
-
-
-@pytest.fixture
-def setlocale():
-    """Allow temporary modification of locale settings."""
-    saved_locale_settings = {
-        category: locale.getlocale(getattr(locale, category))
-        for category in dir(locale)
-        if category.startswith("LC_") and category != "LC_ALL"
-    }
-
-    yield locale.setlocale
-
-    for category, locale_settings in saved_locale_settings.items():
-        locale.setlocale(getattr(locale, category), locale_settings)
 
 
 class TestPkgHistoryProcessor:
@@ -342,9 +326,9 @@ class TestPkgHistoryProcessor:
         ),
     )
     @pytest.mark.repo_config(converted=True)
-    def test_run(self, testcase, specfile, specfile_content, repo, processor, setlocale):
+    def test_run(self, testcase, specfile, specfile_content, repo, processor, locale):
         if testcase == "locale-set":
-            setlocale(locale.LC_ALL, "de_DE.UTF-8")
+            locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")
 
         all_results = "all-results" in testcase
 


### PR DESCRIPTION
```
commit da1ee57b3f08548c47a0368c3c47fac5a5116487
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Feb 8 18:01:43 2024 +0100

    Ensure locale modifications stay isolated in tests
    
    Rename and refactor the setlocale() fixture for this and make it
    generally available.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 8cf6d66aec5aec7daa7f92e964fdbb2a3d3829ff (main--tests-break-encoding)
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Feb 8 18:05:37 2024 +0100

    Extract unpacking repo from test_process_distgit
    
    This makes the function a little less unwieldy.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 13384aeb2716cda21dc6e873d0ba3a68fc65b28f
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Feb 8 18:36:09 2024 +0100

    Test process_distgit.main() functionally
    
    Previously, this only checked if process_distgit.process_distgit() was
    called correctly. It’s easy enough to test that the whole operation
    works.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit f99889d52b98050e2e0a3abac680ab9a2f7b25ef
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Feb 7 19:12:14 2024 +0100

    Cope better with non-ASCII encodings in spec files
    
    This broke with the change to use the rpm Python package to expand
    macros in-process. The reason was that the %lua_requires macro set the
    locale to "C" (_not_ "C.UTF-8") as a side effect which caused text files
    to be opened with "ascii" encoding from then on.
    
    Fixes: #64
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```

Fixes: #64