### PR TITLE
Suppress superfluous rpm output, report current parse errors instead

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,4 @@ allowed-confusables = ["’"]
 
 [tool.pytest.ini_options]
 addopts = "--cov --cov-config .coveragerc --cov-report term --cov-report xml --cov-report html"
+tmp_path_retention_policy = "failed"

--- a/rpmautospec/exc.py
+++ b/rpmautospec/exc.py
@@ -1,5 +1,18 @@
+from typing import Optional
+
+
 class RpmautospecException(Exception):
     """Base class for rpmautospec exceptions."""
+
+    def __init__(self, *args, code: Optional[str] = None, detail: Optional[str] = None):
+        super().__init__(*args)
+        self.code = code
+        self.detail = detail
+
+    def __str__(self):
+        if self.detail:
+            return f"{', '.join(self.args)}:\n{self.detail}"
+        return super().__str__()
 
 
 class SpecParseFailure(RpmautospecException):

--- a/rpmautospec/subcommands/changelog.py
+++ b/rpmautospec/subcommands/changelog.py
@@ -39,9 +39,12 @@ def produce_changelog(
 ) -> str:
     processor = PkgHistoryProcessor(spec_or_repo)
     result = processor.run(visitors=(processor.release_number_visitor, processor.changelog_visitor))
-    if error_on_unparseable_spec and result["epoch-version"] is None:
-        # If epoch-version is None, this indicates that the spec file couldn’t be parsed.
-        raise SpecParseFailure(f"Couldn’t parse spec file {processor.specfile.name}")
+    error = result["verflags"].get("error")
+    if error and error_on_unparseable_spec:
+        error_detail = result["verflags"]["error-detail"]
+        raise SpecParseFailure(
+            f"Couldn’t parse spec file {processor.specfile.name}", code=error, detail=error_detail
+        )
     return collate_changelog(result)
 
 

--- a/rpmautospec/subcommands/process_distgit.py
+++ b/rpmautospec/subcommands/process_distgit.py
@@ -95,9 +95,12 @@ def process_distgit(
         visitors.append(processor.changelog_visitor)
     result = processor.run(visitors=visitors)
 
-    if error_on_unparseable_spec and result["epoch-version"] is None:
-        # If epoch-version is None, this indicates that the spec file couldn’t be parsed.
-        raise SpecParseFailure(f"Couldn’t parse spec file {processor.specfile.name}")
+    error = result["verflags"].get("error")
+    if error and error_on_unparseable_spec:
+        error_detail = result["verflags"]["error-detail"]
+        raise SpecParseFailure(
+            f"Couldn’t parse spec file {processor.specfile.name}", code=error, detail=error_detail
+        )
 
     autorelease_number = result["release-number"]
 

--- a/rpmautospec/subcommands/release.py
+++ b/rpmautospec/subcommands/release.py
@@ -59,9 +59,12 @@ def calculate_release(
     """
     processor = PkgHistoryProcessor(spec_or_path)
     result = processor.run(visitors=(processor.release_number_visitor,))
-    if error_on_unparseable_spec and result["epoch-version"] is None:
-        # If epoch-version is None, this indicates that the spec file couldn’t be parsed.
-        raise SpecParseFailure(f"Couldn’t parse spec file {processor.specfile.name}")
+    error = result["verflags"].get("error")
+    if error and error_on_unparseable_spec:
+        error_detail = result["verflags"]["error-detail"]
+        raise SpecParseFailure(
+            f"Couldn’t parse spec file {processor.specfile.name}", code=error, detail=error_detail
+        )
     return result["release-complete" if complete_release else "release-number"]
 
 

--- a/tests/rpmautospec/subcommands/test_changelog.py
+++ b/tests/rpmautospec/subcommands/test_changelog.py
@@ -68,13 +68,15 @@ def test_produce_changelog(repo):
 def test_produce_changelog_error():
     with mock.patch.object(changelog, "PkgHistoryProcessor") as PkgHistoryProcessor:
         processor = PkgHistoryProcessor.return_value
-        processor.run.return_value = {"epoch-version": None}
+        processor.run.return_value = {
+            "verflags": {"error": "specfile-parse-error", "error-detail": "BOOP"}
+        }
         processor.specfile.name = "test.spec"
 
         with pytest.raises(SpecParseFailure) as excinfo:
             changelog.produce_changelog("test")
 
-    assert str(excinfo.value) == "Couldn’t parse spec file test.spec"
+    assert str(excinfo.value) == "Couldn’t parse spec file test.spec:\nBOOP"
 
 
 def test_main():

--- a/tests/rpmautospec/subcommands/test_release.py
+++ b/tests/rpmautospec/subcommands/test_release.py
@@ -77,18 +77,19 @@ class TestRelease:
 
             expected_release = "11"
 
-            if method_to_test == "calculate_release":
-                assert (
-                    release.calculate_release(unpacked_repo_dir, error_on_unparseable_spec=True)
-                    == expected_release
-                )
-            else:
-                args = mock.Mock()
-                args.spec_or_path = unpacked_repo_dir
-                release.main(args)
+            with mock.patch("rpm.setLogFile"):
+                if method_to_test == "calculate_release":
+                    assert (
+                        release.calculate_release(unpacked_repo_dir, error_on_unparseable_spec=True)
+                        == expected_release
+                    )
+                else:
+                    args = mock.Mock()
+                    args.spec_or_path = unpacked_repo_dir
+                    release.main(args)
 
-                captured = capsys.readouterr()
-                assert f"Calculated release number: {expected_release}" in captured.out
+                    captured = capsys.readouterr()
+                    assert f"Calculated release number: {expected_release}" in captured.out
 
     def test_calculate_release_error(self):
         with mock.patch.object(release, "PkgHistoryProcessor") as PkgHistoryProcessor:

--- a/tests/rpmautospec/subcommands/test_release.py
+++ b/tests/rpmautospec/subcommands/test_release.py
@@ -94,13 +94,15 @@ class TestRelease:
     def test_calculate_release_error(self):
         with mock.patch.object(release, "PkgHistoryProcessor") as PkgHistoryProcessor:
             processor = PkgHistoryProcessor.return_value
-            processor.run.return_value = {"epoch-version": None}
+            processor.run.return_value = {
+                "verflags": {"error": "specfile-parse-error", "error-detail": "HAHA"}
+            }
             processor.specfile.name = "test.spec"
 
             with pytest.raises(SpecParseFailure) as excinfo:
                 release.calculate_release("test")
 
-        assert str(excinfo.value) == "Couldn’t parse spec file test.spec"
+        assert str(excinfo.value) == "Couldn’t parse spec file test.spec:\nHAHA"
 
     def test_calculate_release_number(self):
         with mock.patch.object(release, "calculate_release") as calculate_release:

--- a/tests/rpmautospec/test_exc.py
+++ b/tests/rpmautospec/test_exc.py
@@ -1,0 +1,13 @@
+from rpmautospec import exc
+
+
+class TestRpmautospecException:
+    def test___init__(self):
+        e = exc.RpmautospecException("foo", "bar", code="code", detail="detail")
+        assert e.args == ("foo", "bar")
+        assert e.code == "code"
+        assert e.detail == "detail"
+
+    def test___str__(self):
+        e = exc.RpmautospecException("foo", "bar", code="code", detail="detail")
+        assert str(e) == "foo, bar:\ndetail"

--- a/tests/rpmautospec/test_pkg_history.py
+++ b/tests/rpmautospec/test_pkg_history.py
@@ -16,6 +16,7 @@ from rpmautospec import pkg_history
 @pytest.fixture
 def processor(repo):
     processor = pkg_history.PkgHistoryProcessor(repo.workdir)
+    processor.repo = repo
     return processor
 
 


### PR DESCRIPTION
```
commit 9db5dc52bf2f0fb6ae983ba7673a3b2de545449c
Author: Nils Philippsen <nils@redhat.com>
Date:   Fri Feb 16 11:09:16 2024 +0100

    Don’t retain temporary files unnecessarily
    
    The test suite creates a lot of temporary files (about 1GB per run currently),
    don’t retain them unless there are failures to be debugged.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 443f1a43fd24d2b45a246e5664962af29de87a78
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Feb 15 23:52:05 2024 +0100

    Inject repo fixture into processor fixture
    
    This avoids having to different Repository objects for the same
    repository in tests which can cause hard to debug test failures.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 8f09ca6ac81c0e964af66739b6cbff5b71af1cb3
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Feb 15 23:50:38 2024 +0100

    Add details to custom exceptions
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit abd97722ee05328e98b2ac800ce375caf5f3942e
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Feb 15 20:56:55 2024 +0100

    Don’t leak RPM error messages to stderr
    
    Fixes: #70
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 832226515236b4a60103acc15f657bcbf9395949
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Feb 15 23:54:16 2024 +0100

    Report parse errors of the current spec file
    
    To do that, refactor PkgHistoryProcessor._get_rpmverflags*() to always
    return a dictionary which can carry details about errors, and store this
    information with the processed commits.
    
    Fixes: #72
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```

Fixes: #70
Fixes: #72