### PR TITLE
Fix with pygit2 < 1.13.3

### DIFF
--- a/rpmautospec/compat.py
+++ b/rpmautospec/compat.py
@@ -1,0 +1,19 @@
+from io import BytesIO
+
+import pygit2
+
+
+class MinimalBlobIO:
+    """Minimal substitute for pygit2.BlobIO for old pygit2 versions.
+
+    This doesn’t do any of the filtering"""
+
+    def __init__(self, blob: pygit2.Blob, *, as_path: str = None, commit_id: pygit2.Oid = None):
+        self.blob = blob
+        # the rest is ignored
+
+    def __enter__(self):
+        return BytesIO(self.blob.data)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass

--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -12,6 +12,11 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Any, Optional, Sequence, Union
 
 import pygit2
+
+try:
+    from pygit2 import BlobIO
+except ImportError:  # pragma: no cover
+    from .compat import MinimalBlobIO as BlobIO
 from rpmautospec_core import AUTORELEASE_MACRO
 
 import rpm
@@ -43,7 +48,7 @@ def _checkout_tree_files(
             if stat.S_ISLNK(entry.filemode):
                 fpath.symlink_to(entry.data)
             else:  # stat.S_ISREG(entry.filemode)
-                with pygit2.BlobIO(entry, as_path=str(relpath), commit_id=commit.id) as f:
+                with BlobIO(entry, as_path=str(relpath), commit_id=commit.id) as f:
                     fpath.write_bytes(f.read())
                 fpath.chmod(stat.S_IMODE(entry.filemode))
 

--- a/tests/rpmautospec/test_compat.py
+++ b/tests/rpmautospec/test_compat.py
@@ -1,0 +1,10 @@
+from unittest import mock
+
+from rpmautospec import compat
+
+
+def test_minimal_blob_io():
+    test_data = b"Hello"
+    blob = mock.Mock(data=test_data)
+    with compat.MinimalBlobIO(blob) as f:
+        assert f.read() == test_data


### PR DESCRIPTION
Prior to this version, pygit2 didn’t have the BlobIO class. For our purposes, we don’t need the filtering capability, so use a thin compat class if BlobIO isn’t available.

Fixes: #77