### PR TITLE
Fix detecting spec file parsing errors

### DIFF
--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -248,7 +248,7 @@ class PkgHistoryProcessor:
         execution to process these and finally yield back the results for this
         commit.
         """
-        verflags = self._get_rpmverflags_for_commit(commit)
+        commit_verflags = verflags = self._get_rpmverflags_for_commit(commit)
 
         if "error" not in verflags:
             epoch_version = verflags["epoch-version"]
@@ -284,7 +284,7 @@ class PkgHistoryProcessor:
         # for this commit and parent results as dictionaries on resume.
         commit_result, parent_results = yield {"child_must_continue": child_must_continue}
 
-        commit_result["verflags"] = verflags
+        commit_result["verflags"] = commit_verflags
         commit_result["epoch-version"] = epoch_version
         commit_result["magic-comment-result"] = parse_magic_comments(commit.message)
 

--- a/tests/rpmautospec/test_pkg_history.py
+++ b/tests/rpmautospec/test_pkg_history.py
@@ -510,3 +510,10 @@ class TestPkgHistoryProcessor:
                 )
 
         assert all("error" not in entry for entry in changelog)
+
+        verflags = res["verflags"]
+        assert verflags["base"] == 1
+        assert verflags["epoch-version"] == "1.0"
+        assert verflags["extraver"] is None
+        assert verflags["prerelease"] is None
+        assert verflags["snapinfo"] is None


### PR DESCRIPTION
As it was, the results of a commit could be polluted by that of a parent.

Fixes: #82