### PR TITLE
Revert "Run tests serialized with Python < 3.12"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,14 +14,12 @@ setenv =
 # erroneously doesn’t count a `break` statement which clearly is executed (as
 # the preceding statements which aren’t flagged).
   py39: COV_FAIL_UNDER = 99
-# Run tests serialized with Python < 3.12 as workers in GitHub CI started crashing.
-  py{39,310,311}: RUN_TESTS_PARALLEL =
 skip_install = true
 sitepackages = false
 commands_pre =
   poetry install --all-extras
 commands =
-  pytest --import-mode importlib {env:RUN_TESTS_PARALLEL:-n auto} -o 'addopts=--cov --cov-config .coveragerc --cov-report term --cov-report xml --cov-report html --cov-fail-under {env:COV_FAIL_UNDER:100}' tests/
+  pytest --import-mode importlib -n auto -o 'addopts=--cov --cov-config .coveragerc --cov-report term --cov-report xml --cov-report html --cov-fail-under {env:COV_FAIL_UNDER:100}' tests/
 
 [testenv:black]
 deps = black


### PR DESCRIPTION
This reverts commit cb18c67c7e6026c593f08a6aa8c68d31bd24c003 which was based on a wrong assumption.