### PR TITLE
Fix wonky histories

### DIFF
--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -582,6 +582,11 @@ class PkgHistoryProcessor:
                         for vindex, v in enumerate(visitors)
                     ]
 
+                    log.debug(
+                        "children_visitors_info[]['child_must_continue']: %s",
+                        [info["child_must_continue"] for info in children_visitors_info],
+                    )
+
                     keep_processing = keep_processing and any(  # pragma: no branch
                         info["child_must_continue"] for info in children_visitors_info
                     )
@@ -589,6 +594,7 @@ class PkgHistoryProcessor:
                 snippet.append(commit)
 
                 if keep_processing:
+                    log.debug("Keep processing: commit %s", commit.id)
                     # Create visitor coroutines for the commit from the functions passed into this
                     # method. Pass the ordered list of "is there a child whose coroutine of the same
                     # visitor wants to continue" into it.
@@ -603,6 +609,7 @@ class PkgHistoryProcessor:
                     # Only traverse this commit. Traversal is important if parent commits are the
                     # root of branches that affect the results (computed release number and
                     # generated changelog).
+                    log.debug("Only traversing: commit %s", commit.id)
                     commit_coroutines[commit] = coroutines = None
                     commit_coroutines_info[commit] = [
                         {"child_must_continue": False} for v in visitors
@@ -657,7 +664,7 @@ class PkgHistoryProcessor:
                 if commit_coroutines[commit] is None:
                     # Only traverse, but don't process this commit. Ancestral commits might have to
                     # be taken into account again, so we can’t simply stop here.
-                    log.debug("\tonly traverse")
+                    log.debug("\tonly traverse: %s", commit.id)
                     continue
 
                 for p in commit.parents:

--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -443,6 +443,8 @@ class PkgHistoryProcessor:
                     log.debug("\tno parent to follow")
                 previous_changelog = ()
                 for candidate in parent_results:
+                    if not candidate:
+                        continue
                     if candidate["commit-id"] == parent_to_follow.id:
                         previous_changelog = candidate.get("changelog", ())
                         skip_for_changelog = True

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,3 +1,84 @@
+import pygit2
+from pygit2.enums import DeltaStatus
+
+SPEC_FILE_TEMPLATE = """Summary: Boo
+Name: boo
+{version}
+{release}
+License: CC0
+
+%description
+Boo
+
+{prep}
+
+{changelog}
+"""
+
+_UNSET = object()
+
+
+def create_commit(
+    repo,
+    *,
+    reference_name=_UNSET,
+    tree_id=None,
+    parents=_UNSET,
+    author=None,
+    committer=None,
+    message="Changed something",
+    create_branch=_UNSET,
+):
+    if not isinstance(repo, pygit2.Repository):
+        repo = pygit2.Repository(repo)
+    if not author:
+        author = repo.default_signature
+    if not committer:
+        committer = repo.default_signature
+
+    if reference_name and reference_name is not _UNSET:
+        repo.checkout(reference_name)
+
+    index = repo.index
+
+    for delta in repo.diff().deltas:
+        if delta.status in (DeltaStatus.ADDED, DeltaStatus.MODIFIED):
+            index.add(delta.new_file.path)
+        elif delta.status == DeltaStatus.DELETED:
+            index.remove(delta.old_file.path)
+    index.add_all()
+    index.write()
+
+    _tree_id = index.write_tree()
+
+    if not tree_id:
+        tree_id = _tree_id
+
+    parent_id = None
+    if reference_name is _UNSET:
+        parent, reference = repo.resolve_refish(repo.head.name)
+        parent_id = parent.id
+        reference_name = reference.name
+    elif reference_name:
+        parent_id = repo.head.target
+
+    if parents is _UNSET:
+        if parent_id:
+            parents = [parent_id]
+        else:
+            parents = []
+
+    oid = repo.create_commit(reference_name, author, committer, message, tree_id, parents)
+    commit = repo[oid]
+
+    if create_branch is not _UNSET:
+        repo.branches.local.create(create_branch or "rawhide", commit)
+
+    repo.checkout_tree(commit.tree, strategy=pygit2.GIT_CHECKOUT_FORCE)
+
+    return {"oid": oid, "commit": commit}
+
+
 class MainArgs:
     """Substitute for argparse.Namespace for tests
 


### PR DESCRIPTION
commit 53f9f00c6217dd5acd5402f4438904ebc92902db
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Jun 13 16:04:05 2024 +0200

    Refactor creating commits in test repos
    
    Previously, this was a couple of copy-pasted snippets of mostly boiler
    plate. Move that into a convenience function, also make the spec file
    template better accessible to use in individual tests.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit b5d7308653004f81098bdcc8b475a825c21ad950
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Jun 13 21:20:55 2024 +0200

    Expose skipping various steps in the repo fixture
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 7506bd192fd9e9a4aa8f06118c0609c7529ec833
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Jun 18 13:45:33 2024 +0200

    Add more debugging output
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit c99da5b1eb7d720b30cc2d128630665d1e88da03
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Jun 18 13:38:44 2024 +0200

    Fix tripping over traverse-only commits
    
    Previously, certain non-linear histories which involved converstion to
    and/or fixing use of rpmautospec attempted to process commits that were
    marked to only be traversed before and errored out because no
    information was collected.
    
    Background:
    - Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2278226
    - kpmcore package:
      https://src.fedoraproject.org/rpms/kpmcore/c/0ae7de895cc2b9aca799397350b5df1440c0005d?branch=epel9
    - kde-partitionmanager package:
      https://src.fedoraproject.org/rpms/kde-partitionmanager/c/e8f4b3bd55c0c76b41e5943747d89e1507bf9ca3?branch=epel9
    
    Fixes: #139
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>