### PR TITLE
convert: Present exceptions more nicely

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,4 +208,4 @@ def repo(repopath, specfile, specfile_content, _repo_config):
 
 @pytest.fixture
 def cli_runner() -> CliRunner:
-    return CliRunner()
+    return CliRunner(mix_stderr=False)


### PR DESCRIPTION
Wrap them in ClickException, so tracebacks aren’t shown to users.

Fixes: #172