### PR TITLE
Use `ruff format` instead of `black`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,4 +73,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: run tests through tox
-        run: "tox -e black,ruff"
+        run: "tox -e format,lint"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,17 +7,12 @@ repos:
       - id: check-added-large-files
       - id: check-yaml
       - id: debug-statements
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     hooks:
-      - id: flake8
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
-    hooks:
-      - id: black
-        args:
-          - --diff
-          - --check
+      - id: ruff
+        types: [file, python]
+      - id: ruff-format
+        types: [file, python]
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.29.0
     hooks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,52 +15,6 @@ files = [
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
-name = "black"
-version = "24.8.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "black-24.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09cdeb74d494ec023ded657f7092ba518e8cf78fa8386155e4a03fdcc44679e6"},
-    {file = "black-24.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:81c6742da39f33b08e791da38410f32e27d632260e599df7245cccee2064afeb"},
-    {file = "black-24.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:707a1ca89221bc8a1a64fb5e15ef39cd755633daa672a9db7498d1c19de66a42"},
-    {file = "black-24.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d6417535d99c37cee4091a2f24eb2b6d5ec42b144d50f1f2e436d9fe1916fe1a"},
-    {file = "black-24.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fb6e2c0b86bbd43dee042e48059c9ad7830abd5c94b0bc518c0eeec57c3eddc1"},
-    {file = "black-24.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:837fd281f1908d0076844bc2b801ad2d369c78c45cf800cad7b61686051041af"},
-    {file = "black-24.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62e8730977f0b77998029da7971fa896ceefa2c4c4933fcd593fa599ecbf97a4"},
-    {file = "black-24.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:72901b4913cbac8972ad911dc4098d5753704d1f3c56e44ae8dce99eecb0e3af"},
-    {file = "black-24.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:7c046c1d1eeb7aea9335da62472481d3bbf3fd986e093cffd35f4385c94ae368"},
-    {file = "black-24.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:649f6d84ccbae73ab767e206772cc2d7a393a001070a4c814a546afd0d423aed"},
-    {file = "black-24.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b59b250fdba5f9a9cd9d0ece6e6d993d91ce877d121d161e4698af3eb9c1018"},
-    {file = "black-24.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:6e55d30d44bed36593c3163b9bc63bf58b3b30e4611e4d88a0c3c239930ed5b2"},
-    {file = "black-24.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:505289f17ceda596658ae81b61ebbe2d9b25aa78067035184ed0a9d855d18afd"},
-    {file = "black-24.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b19c9ad992c7883ad84c9b22aaa73562a16b819c1d8db7a1a1a49fb7ec13c7d2"},
-    {file = "black-24.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f13f7f386f86f8121d76599114bb8c17b69d962137fc70efe56137727c7047e"},
-    {file = "black-24.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:f490dbd59680d809ca31efdae20e634f3fae27fba3ce0ba3208333b713bc3920"},
-    {file = "black-24.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eab4dd44ce80dea27dc69db40dab62d4ca96112f87996bca68cd75639aeb2e4c"},
-    {file = "black-24.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3c4285573d4897a7610054af5a890bde7c65cb466040c5f0c8b732812d7f0e5e"},
-    {file = "black-24.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e84e33b37be070ba135176c123ae52a51f82306def9f7d063ee302ecab2cf47"},
-    {file = "black-24.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:73bbf84ed136e45d451a260c6b73ed674652f90a2b3211d6a35e78054563a9bb"},
-    {file = "black-24.8.0-py3-none-any.whl", hash = "sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed"},
-    {file = "black-24.8.0.tar.gz", hash = "sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "cffi"
 version = "1.17.0"
 description = "Foreign Function Interface for Python calling C code."
@@ -308,17 +262,6 @@ files = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
-
-[[package]]
 name = "packaging"
 version = "24.1"
 description = "Core utilities for Python packages"
@@ -328,33 +271,6 @@ files = [
     {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
     {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.2.2"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "platformdirs-4.2.2-py3-none-any.whl", hash = "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee"},
-    {file = "platformdirs-4.2.2.tar.gz", hash = "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"},
-]
-
-[package.extras]
-docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
-type = ["mypy (>=1.8)"]
 
 [[package]]
 name = "pluggy"
@@ -655,18 +571,7 @@ files = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 
-[[package]]
-name = "typing-extensions"
-version = "4.12.2"
-description = "Backported and Experimental Type Hints for Python 3.8+"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
-]
-
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d8d14add61d93f905d6331bbe671087fa56c5ee43b8d584299f55370980dee62"
+content-hash = "86242ac511723d0b7ca1059cd3e6a95de4d609c677814b0edf2ad7a98b4c7d99"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[project]
+requires-python = ">=3.9"
+
 [tool.poetry]
 name = "rpmautospec"
 version = "0.7.1"
@@ -57,7 +60,6 @@ pytest-xdist = [
     { version = "^2.5.0 || ^3", python = "^3.12" }
 ]
 coverage = "^7.2.0"
-black = "^24.1.0"
 ruff = "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0"
 
 [tool.poetry.scripts]
@@ -71,9 +73,6 @@ rpmautospec = "rpmautospec.cli:cli"
 
 [tool.poetry.build]
 generate-setup-file = true
-
-[tool.black]
-line_length = 100
 
 [tool.ruff]
 line-length = 100
@@ -89,3 +88,6 @@ allowed-confusables = ["’"]
 [tool.pytest.ini_options]
 addopts = "--cov --cov-config .coveragerc --cov-report term --cov-report xml --cov-report html"
 tmp_path_retention_policy = "failed"
+
+[tool.black]
+line_length = 100

--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -139,9 +139,12 @@ class PkgHistoryProcessor:
             rpm.addMacro("_sourcedir", f"{path}")
             rpm.addMacro("_builddir", f"{path}")
 
-            with specfile.open(mode="rb") as unabridged, NamedTemporaryFile(
-                mode="wb", prefix=f"rpmautospec-abridged-{name}-", suffix=".spec"
-            ) as abridged:
+            with (
+                specfile.open(mode="rb") as unabridged,
+                NamedTemporaryFile(
+                    mode="wb", prefix=f"rpmautospec-abridged-{name}-", suffix=".spec"
+                ) as abridged,
+            ):
                 # Attempt to parse a shortened version of the spec file first, to speed up
                 # processing in certain cases. This includes all lines before `%prep`, i.e. in most
                 # cases everything which is needed to make RPM parsing succeed and contain the info

--- a/rpmautospec/subcommands/process_distgit.py
+++ b/rpmautospec/subcommands/process_distgit.py
@@ -85,11 +85,12 @@ def do_process_distgit(
 
     autorelease_number = result["release-number"]
 
-    with processor.specfile.open(
-        "r", encoding="utf-8", errors="surrogateescape"
-    ) as specfile, tempfile.NamedTemporaryFile(
-        "w", encoding="utf-8", errors="surrogateescape"
-    ) as tmp_specfile:
+    with (
+        processor.specfile.open("r", encoding="utf-8", errors="surrogateescape") as specfile,
+        tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", errors="surrogateescape"
+        ) as tmp_specfile,
+    ):
         # Process the spec file into a temporary file...
         used_features = []
 

--- a/tests/rpmautospec/subcommands/test_changelog.py
+++ b/tests/rpmautospec/subcommands/test_changelog.py
@@ -69,9 +69,10 @@ def test_do_generate_changelog_error():
 
 
 def test_generate_changelog(cli_runner):
-    with mock.patch.object(
-        changelog, "do_generate_changelog"
-    ) as do_generate_changelog, mock.patch.object(changelog, "pager") as pager:
+    with (
+        mock.patch.object(changelog, "do_generate_changelog") as do_generate_changelog,
+        mock.patch.object(changelog, "pager") as pager,
+    ):
         generated_changelog = do_generate_changelog.return_value
 
         pager_sentinel = object()

--- a/tests/rpmautospec/subcommands/test_process_distgit.py
+++ b/tests/rpmautospec/subcommands/test_process_distgit.py
@@ -119,9 +119,10 @@ def fuzz_spec_file(
 ):
     """Fuzz a spec file in ways which (often) shouldn't change the outcome"""
     new_spec_file_path = spec_file_path.with_name(spec_file_path.name + ".new")
-    with spec_file_path.open("r", encoding="utf-8") as orig, new_spec_file_path.open(
-        "w", encoding="utf-8"
-    ) as new:
+    with (
+        spec_file_path.open("r", encoding="utf-8") as orig,
+        new_spec_file_path.open("w", encoding="utf-8") as new,
+    ):
         if is_processed:
             autorelease_blurb = process_distgit.AUTORELEASE_TEMPLATE.format(autorelease_number=15)
             print(
@@ -353,9 +354,10 @@ def test_do_process_distgit(
         / "dummy-test-package-gloster.spec.expected"
     )
 
-    with tempfile.NamedTemporaryFile(mode="w+", encoding="utf8") as tmpspec, open(
-        expected_spec_file_path, "r", encoding="utf-8"
-    ) as expspec:
+    with (
+        tempfile.NamedTemporaryFile(mode="w+", encoding="utf8") as tmpspec,
+        open(expected_spec_file_path, "r", encoding="utf-8") as expspec,
+    ):
         # Copy expected spec file and potentially bump release number
         relnum_seen = None
         relnumdef_re = re.compile(

--- a/tests/rpmautospec/test_cli.py
+++ b/tests/rpmautospec/test_cli.py
@@ -12,9 +12,11 @@ def test_setup_logging(log_level_name):
     """Test the setup_logging() function."""
     log_level = getattr(logging, log_level_name)
 
-    with mock.patch.object(cli.logging, "StreamHandler") as StreamHandler, mock.patch.object(
-        cli.logging, "lastResort"
-    ) as lastResort, mock.patch.object(cli.logging, "basicConfig") as basicConfig:
+    with (
+        mock.patch.object(cli.logging, "StreamHandler") as StreamHandler,
+        mock.patch.object(cli.logging, "lastResort") as lastResort,
+        mock.patch.object(cli.logging, "basicConfig") as basicConfig,
+    ):
         info_handler = StreamHandler.return_value
         cli.setup_logging(log_level)
 

--- a/tests/rpmautospec/test_pager.py
+++ b/tests/rpmautospec/test_pager.py
@@ -15,9 +15,10 @@ def test_page(testcase):
     else:
         os.environ.pop("RPMAUTOSPEC_LESS", None)
 
-    with mock.patch.object(pager.pydoc, "pager") as pydoc_pager, mock.patch.object(
-        pager, "print"
-    ) as print:
+    with (
+        mock.patch.object(pager.pydoc, "pager") as pydoc_pager,
+        mock.patch.object(pager, "print") as print,
+    ):
         pager.page("Hello!", enabled="enabled" in testcase)
 
     if "disabled" in testcase:

--- a/tests/rpmautospec/test_pkg_history.py
+++ b/tests/rpmautospec/test_pkg_history.py
@@ -274,11 +274,14 @@ class TestPkgHistoryProcessor:
                 )
             ]
 
-        with mock.patch.object(
-            processor, "_get_rpmverflags", wraps=processor._get_rpmverflags
-        ) as _get_rpmverflags, mock.patch.object(
-            pkg_history, "_checkout_tree_files", side_effect=pkg_history._checkout_tree_files
-        ) as _checkout_tree_files:
+        with (
+            mock.patch.object(
+                processor, "_get_rpmverflags", wraps=processor._get_rpmverflags
+            ) as _get_rpmverflags,
+            mock.patch.object(
+                pkg_history, "_checkout_tree_files", side_effect=pkg_history._checkout_tree_files
+            ) as _checkout_tree_files,
+        ):
             side_effect = [mock.DEFAULT]
             if needs_full_repo:
                 side_effect.insert(0, {"error": "specfile-parse-error"})

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 minversion = 3.9.0
 envlist =
-  black
-  ruff
+  format
+  lint
   py{39,310,311,312}
 isolated_build = true
 skip_missing_interpreters = true
@@ -21,12 +21,12 @@ commands_pre =
 commands =
   pytest --import-mode importlib -n auto -o 'addopts=--cov --cov-config .coveragerc --cov-report term --cov-report xml --cov-report html --cov-fail-under {env:COV_FAIL_UNDER:100}' tests/
 
-[testenv:black]
-deps = black
+[testenv:format]
+deps = ruff
 commands_pre =
-commands = black --check --diff rpmautospec/ tests/
+commands = ruff format --diff rpmautospec/ tests/
 
-[testenv:ruff]
+[testenv:lint]
 deps = ruff
 commands_pre =
 commands = ruff check rpmautospec/ tests/


### PR DESCRIPTION
This arguably makes `with ...` over multiple lines more readable (on top of fewer dependencies).