### PR TITLE
Accommodate increased robustness in RPM 4.20

### DIFF
--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -171,10 +171,7 @@ class PkgHistoryProcessor:
                         else:
                             error = False
                             rpmerr_out = None
-                            # Parsing this candidate spec file succeeded. In the case of the
-                            # abridged spec file, we can skip parsing the full spec file.
-                            if spec_candidate == abridged.name:
-                                break
+                            break
         finally:
             rpm.setLogFile(sys.stderr)
             rpm.reloadConfig()

--- a/tests/rpmautospec/test_pkg_history.py
+++ b/tests/rpmautospec/test_pkg_history.py
@@ -194,7 +194,7 @@ class TestPkgHistoryProcessor:
         ids=("with-prep", "without-prep", "with-prep-inadequate"),
         indirect=True,
     )
-    def test__get_rpm_verflags(self, testcase, release, prep, specfile, processor, caplog):
+    def test__get_rpmverflags(self, testcase, release, prep, specfile, processor, caplog):
         with_name = "with-name" in testcase
         specfile_missing = "specfile-missing" in testcase
         specfile_broken = "specfile-broken" in testcase


### PR DESCRIPTION
RPM prior to version 4.20 failed to parse some abridged spec files. Newer versions are more robust, so the fall back path won’t be used.