### PR TITLE
Document `-b` option in `%autorelease` macro.

### DIFF
--- a/doc/autorelease.rst
+++ b/doc/autorelease.rst
@@ -108,6 +108,8 @@ those added fields:
 * ``-e <extraver>``: Allows specifying the ``extraver`` portion of the release.
 * ``-s <snapinfo>``: Allows specifying the ``snapinfo`` portion of the release.
 
+Moreover, ``-b <base>`` allows overriding the default base release number (the default is 1).
+
 In the modern versioning, those fields are embedded in the package `Version` instead.
 
 .. _prerelease example:


### PR DESCRIPTION
While this option is parsed and applied correctly, it is not documented in the official documentation. This commit adds the missing documentation.