### PR TITLE
CLI: Don’t crash on spec file parsing errors

### DIFF
--- a/rpmautospec/subcommands/changelog.py
+++ b/rpmautospec/subcommands/changelog.py
@@ -39,7 +39,10 @@ def do_generate_changelog(
 @handle_expected_exceptions
 def generate_changelog(obj: dict[str, Any], spec_or_path: Path) -> None:
     """Generate changelog entries from git commit logs"""
-    changelog = do_generate_changelog(
-        spec_or_path, error_on_unparseable_spec=obj["error_on_unparseable_spec"]
-    )
+    try:
+        changelog = do_generate_changelog(
+            spec_or_path, error_on_unparseable_spec=obj["error_on_unparseable_spec"]
+        )
+    except SpecParseFailure as exc:
+        raise click.ClickException(*exc.args) from exc
     pager.page(changelog, enabled=obj["pager"])

--- a/rpmautospec/subcommands/process_distgit.py
+++ b/rpmautospec/subcommands/process_distgit.py
@@ -151,6 +151,9 @@ def do_process_distgit(
 @handle_expected_exceptions
 def process_distgit(obj: dict[str, Any], spec_or_path: Path, target: Path) -> None:
     """Work repository history and commit logs into a spec file"""
-    do_process_distgit(
-        spec_or_path, target, error_on_unparseable_spec=obj["error_on_unparseable_spec"]
-    )
+    try:
+        do_process_distgit(
+            spec_or_path, target, error_on_unparseable_spec=obj["error_on_unparseable_spec"]
+        )
+    except SpecParseFailure as exc:
+        raise click.ClickException(*exc.args) from exc

--- a/rpmautospec/subcommands/release.py
+++ b/rpmautospec/subcommands/release.py
@@ -68,9 +68,12 @@ def do_calculate_release_number(
 @handle_expected_exceptions
 def calculate_release(obj: dict[str, Any], complete_release: bool, spec_or_path: Path) -> None:
     """Calculate the next release tag for a package build"""
-    release = do_calculate_release(
-        spec_or_path,
-        complete_release=complete_release,
-        error_on_unparseable_spec=obj["error_on_unparseable_spec"],
-    )
+    try:
+        release = do_calculate_release(
+            spec_or_path,
+            complete_release=complete_release,
+            error_on_unparseable_spec=obj["error_on_unparseable_spec"],
+        )
+    except SpecParseFailure as exc:
+        raise click.ClickException(*exc.args) from exc
     print("Calculated release number:", release)

--- a/tests/rpmautospec/subcommands/test_convert.py
+++ b/tests/rpmautospec/subcommands/test_convert.py
@@ -158,7 +158,6 @@ class TestPkgConverter:
 
 @mock.patch.object(convert, "PkgConverter")
 def test_convert_empty_commit_message(PkgConverter, cli_runner, specfile):
-    # with pytest.raises(click.UsageError, match="Commit message cannot be empty"):
     result = cli_runner.invoke(
         convert.convert, ["--commit", "--message=", str(specfile)], catch_exceptions=False
     )
@@ -168,7 +167,6 @@ def test_convert_empty_commit_message(PkgConverter, cli_runner, specfile):
 
 @mock.patch.object(convert, "PkgConverter")
 def test_convert_no_changes(PkgConverter, cli_runner, specfile):
-    # with pytest.raises(ValueError, match="All changes are disabled"):
     result = cli_runner.invoke(
         convert.convert, ["--no-changelog", "--no-release", str(specfile)], catch_exceptions=False
     )

--- a/tests/rpmautospec/subcommands/test_release.py
+++ b/tests/rpmautospec/subcommands/test_release.py
@@ -63,6 +63,23 @@ class TestRelease:
 
                     assert f"Calculated release number: {expected_release}" in result.stdout
 
+    def test_calculate_release_specfile_parse_failure(self, cli_runner):
+        error_on_unparseable_spec_sentinel = object()
+        ctx_obj = {"error_on_unparseable_spec": error_on_unparseable_spec_sentinel}
+
+        with mock.patch.object(release, "do_calculate_release") as do_calculate_release:
+            do_calculate_release.side_effect = release.SpecParseFailure("BOO")
+            result = cli_runner.invoke(release.calculate_release, ["some_path"], obj=ctx_obj)
+
+        do_calculate_release.assert_called_once_with(
+            "some_path",
+            complete_release=True,
+            error_on_unparseable_spec=error_on_unparseable_spec_sentinel,
+        )
+
+        assert result.exit_code != 0
+        assert "Error: BOO" in result.stderr
+
     def test_do_calculate_release_error(self, cli_runner):
         with mock.patch.object(release, "PkgHistoryProcessor") as PkgHistoryProcessor:
             processor = PkgHistoryProcessor.return_value


### PR DESCRIPTION
commit 68d62eea23e6563d194432bb1e09489c5ecafffb
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Oct 8 17:41:07 2024 +0200

    tests: remove commented out obsolete lines
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit b8a4aded4247ce66114e21f739431c00655caf32
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Oct 9 10:58:08 2024 +0200

    CLI: Don’t crash on spec file parsing errors
    
    Fixes: #189
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>