### PR TITLE
Improve handling and fix testing abridged spec files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ target-version = "py39"
 select = ["E", "F", "W", "I"]
 allowed-confusables = ["’"]
 
+[tool.ruff.lint.isort]
+known-third-party = ["rpm"]
+
 [tool.ruff.lint.per-file-ignores]
 "**/__init__.py" = ["F401"]
 


### PR DESCRIPTION
commit 42322a967a182fdf8eeda36115b3982982a31d61
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Oct 10 17:07:26 2024 +0200

    Explicitly declare `rpm` a third-party module
    
    This comes to the aid of `ruff check` which confuses it with a system
    library (why ever).
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 9c4708d7a90efebad5950ba3dbf05ce7d583b0ea
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Oct 10 17:09:42 2024 +0200

    Unroll handling (un)abridged spec files
    
    The way it was done previously was too cute by half, looping over the
    abridged and unabridged spec file paths + conditionals galore, which
    confused coverage statistics.
    
    Also to the same end, make parsing the abridged spec file fail in
    relevant tests and don’t rely on rpm (>= 4.20) to do it (see #182).
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>