### PR TITLE
Improve coverage of _get_rpmverflags() unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ target-version = "py39"
 select = ["E", "F", "W", "I"]
 allowed-confusables = ["’"]
 
+[tool.ruff.lint.isort]
+known-third-party = ["rpm"]
+
 [tool.ruff.lint.per-file-ignores]
 "**/__init__.py" = ["F401"]
 

--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -12,14 +12,13 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Any, Optional, Sequence, Union
 
 import pygit2
+import rpm
 
 try:
     from pygit2 import BlobIO
 except ImportError:  # pragma: no cover
     from .compat import MinimalBlobIO as BlobIO
 from rpmautospec_core import AUTORELEASE_MACRO
-
-import rpm
 
 from .changelog import ChangelogEntry
 from .magic_comments import parse_magic_comments
@@ -173,6 +172,8 @@ class PkgHistoryProcessor:
                     finally:
                         rpm.setLogFile(sys.stderr)
                         rpm.reloadConfig()
+            else:
+                pass  # pragma: no cover
         if error:
             if log_error:
                 log.debug("rpm query for %r failed: %s", query, rpmerr_out)


### PR DESCRIPTION
Make parsing the abridged spec file fail in relevant tests and don’t rely on rpm (>= 4.20) to do it, and just tell coverage that the loop is unlikely to finish without being broken out of.

This is a more straight-forward solution than PR#182, i.e. commit a5a2653498522d6f6255d522cb232b42411ebdea.

Also, explicitly declare `rpm` a third-party module. This comes to the aid of `ruff check` which confuses it with a system library (why ever).