### PR TITLE
Handle special cases of process-distgit's target

### DIFF
--- a/rpmautospec/subcommands/process_distgit.py
+++ b/rpmautospec/subcommands/process_distgit.py
@@ -51,6 +51,8 @@ def do_process_distgit(
         target = processor.specfile
     else:
         target = Path(target)
+        if target.is_dir():
+            target /= processor.specfile.name
 
     # Preserve mode of the target spec file if it is overwritten, otherwise use that of the
     # processed spec file. Otherwise it would inherit the 0600 mode of the temporary file.

--- a/rpmautospec/subcommands/process_distgit.py
+++ b/rpmautospec/subcommands/process_distgit.py
@@ -146,7 +146,7 @@ def do_process_distgit(
 
 @click.command()
 @click.argument("spec_or_path", type=click.Path())
-@click.argument("target", type=click.Path())
+@click.argument("target", type=click.Path(), required=False)
 @click.pass_obj
 @handle_expected_exceptions
 def process_distgit(obj: dict[str, Any], spec_or_path: Path, target: Path) -> None:


### PR DESCRIPTION
This PR proposes two minor convenience improvements to the way `process-distgit` handles its argument `target`:

1. Until https://github.com/fedora-infra/rpmautospec/commit/25c8f40bef4b2fb9e410023998cf97d5ab24483d, the command would always overwrite the original spec file. That commit introduced a new argument `target`, which made it possible to store the output elsewhere. This PR exposes the original behavior in the CLI, giving users the option to overwrite the spec file in-place.
2. If the `target` is a directory, the command copies the temporary file with the expanded spec into the directory as-is. The second improvement uses the original spec's name instead of the randomly generated temporary one.