### PR TITLE
Initial implementation of rightmost bumps

### DIFF
--- a/doc/autorelease.rst
+++ b/doc/autorelease.rst
@@ -24,6 +24,12 @@ the different portions of the release field:
   For instance, this can be used to keep release numbers on older Fedora releases way lower than on
   newer ones for the same package version.
 
+* ``-r <minorbump>``: Allows specifying a custom rightmost (minor) release number (the default is 0).
+
+  This is only used when previous commit contained ``[start rightmost]`` line or rightmost number is
+  greater than 0. This provides a different way to ensure release stays lower on older Fedora releases.
+  Rightmost bumps can be started by explicit ``%autorelease -r 1``.
+
 * ``-n``: Don’t render the dist tag, e.g. for use in macros, if the dist tag is added later.
 
 .. important::
@@ -53,6 +59,36 @@ seamlessly.
 
 You don’t have to undo this later, when the version changes, the release will be reset to 1 (or the
 value specified by ``%autorelease -b …``).
+
+Rightmost minor release numbers
+===============================
+
+You can also continue doing only rightmost bumps. Easiest way is to use magic comment in commit::
+
+    [start rightmost]
+
+This would freeze current release number and increment separate number on the right of release.
+
+Use case for this would be for multiple supported branches, which contain equivalent changes.
+Example might be rebased version in multiple branches. But latest branch build should be considered latest,
+even if older stable branch contained more commits modifying spec file. Stable branch can use this
+magic comment to be always lower than development branch like rawhide.
+
+This provides similar functionality to ``rpmdev-bumpspec -r`` tool, but generated from commit messages.
+
+Rightmost bumping release numbers
+=================================
+
+You can bump also the rightmost number to a higher value. Similar to ``bump release`` magic comment,
+you can bump rightmost number to a higher value.::
+
+    [bump rightmost: <number>]
+
+This will start rightmost bumps if not yet started already. Sometimes it might be needed to start
+different number than trailing ``.1`` on right side of the release.
+
+Alternative to this commit line is using ``%autorelease -r …``. You don't have to undo this later,
+it will reset to 1 when version or release number changes.
 
 Examples
 ========
@@ -107,6 +143,7 @@ those added fields:
 * ``-p``: Designates a pre-release, i.e. ``pkgrel`` will be prefixed with ``0.``.
 * ``-e <extraver>``: Allows specifying the ``extraver`` portion of the release.
 * ``-s <snapinfo>``: Allows specifying the ``snapinfo`` portion of the release.
+* ``-r <minorbase>``: Allows specifying the ``minorbump`` portion of the release.
 
 In the modern versioning, those fields are embedded in the package `Version` instead.
 

--- a/rpm_macros.d/macros.rpmautospec
+++ b/rpm_macros.d/macros.rpmautospec
@@ -4,11 +4,12 @@
     print(release_number + base_release_number - 1);
 }%{?-e:.%{-e*}}%{?-s:.%{-s*}}%{!?-n:%{?dist}}%{lua:
     rightmost_number = tonumber(rpm.expand("%{?_rpmautospec_rightmost_number}%{!?_rpmautospec_rightmost_number:0}"));
-    rightmost_base_number = tonumber(rpm.expand("%{{?-r*}}%{{!?-r:0}}));
+    rightmost_base_number = tonumber(rpm.expand("%{?-r*}%{!?-r:0}"));
     if ((rightmost_number + rightmost_base_number) > 0) then
-        string.format(".%d", rightmost_number + rightmost_base_number);
+        print(string.format(".%d", rightmost_number + rightmost_base_number));
     end;
 }
+
 %autochangelog %{lua:
     locale = os.setlocale(nil)
     os.setlocale("C.utf8")

--- a/rpm_macros.d/macros.rpmautospec
+++ b/rpm_macros.d/macros.rpmautospec
@@ -1,8 +1,14 @@
-%autorelease(e:s:pb:n) %{?-p:0.}%{lua:
+%autorelease(e:s:pb:r:n) %{?-p:0.}%{lua:
     release_number = tonumber(rpm.expand("%{?_rpmautospec_release_number}%{!?_rpmautospec_release_number:1}"));
     base_release_number = tonumber(rpm.expand("%{?-b*}%{!?-b:1}"));
     print(release_number + base_release_number - 1);
-}%{?-e:.%{-e*}}%{?-s:.%{-s*}}%{!?-n:%{?dist}}
+}%{?-e:.%{-e*}}%{?-s:.%{-s*}}%{!?-n:%{?dist}}%{lua:
+    rightmost_number = tonumber(rpm.expand("%{?_rpmautospec_rightmost_number}%{!?_rpmautospec_rightmost_number:0}"));
+    rightmost_base_number = tonumber(rpm.expand("%{{?-r*}}%{{!?-r:0}}));
+    if ((rightmost_number + rightmost_base_number) > 0) then
+        string.format(".%d", rightmost_number + rightmost_base_number);
+    end;
+}
 %autochangelog %{lua:
     locale = os.setlocale(nil)
     os.setlocale("C.utf8")

--- a/rpmautospec/magic_comments.py
+++ b/rpmautospec/magic_comments.py
@@ -1,8 +1,11 @@
+import logging
 import re
 import typing
 
+log = logging.getLogger(__name__)
+
 magic_comment_re = re.compile(r"^\s*\[(?P<magic>.*)\]\s*$")
-intvalue_re = re.compile(r"\s*(?P<keyname>[a-z]+([\s_]+[a-z]+)*)\s*(?::\s*)?(?P<value>\d+)\s*")
+intvalue_re = re.compile(r"(?P<keyname>[a-z]+(?:[\s_]+[a-z]+)*)\s*(?::\s*)?(?P<value>\d+)")
 
 
 class MagicCommentResult(typing.NamedTuple):
@@ -10,12 +13,22 @@ class MagicCommentResult(typing.NamedTuple):
 
     skip_changelog: bool = False
     """Do not include this commit in changelog."""
+
     start_rightmost: bool = False
     """Start increasing number on the right of release string, not left."""
+
     bump_release: int = 0
     """Bump release to specified number."""
+
     bump_rightmost: int = 0
     """Bump rightmost (minorbump) of the release to specified number."""
+
+
+types = typing.get_type_hints(MagicCommentResult)
+
+
+def _get_keyname(keyname: str) -> str:
+    return keyname.strip().replace(" ", "_")
 
 
 def parse_magic_comments(message: str) -> MagicCommentResult:
@@ -38,20 +51,29 @@ def parse_magic_comments(message: str) -> MagicCommentResult:
        [bump rightmost: 4]
     """
 
-    types = typing.get_type_hints(MagicCommentResult)
     values = dict()
 
     for line in message.split("\n"):
         if l_match := magic_comment_re.match(line):
             for part in l_match.group("magic").split(","):
-                part = part.strip().replace(" ", "_")
-                if part in types and types[part] is bool:
-                    values[part] = True
-                elif br_match := intvalue_re.match(part):
-                    keyname = br_match.group("keyname")
-                    if keyname in types and types[keyname] is int:
-                        values[keyname] = int(br_match.group("value"))
+                if br_match := intvalue_re.match(part):
+                    keyname = _get_keyname(br_match.group("keyname"))
+                    t = types.get(keyname, None)
+                    value = br_match.group("value")
+                    if types.get(keyname, None) is int:
+                        values[keyname] = int(value)
+                    elif t is not None:
+                        log.warning(f'Parameter "{keyname}" is known, but {t} is not int')
                     else:
-                        raise ValueError(f'Parameter "{keyname}" is not recognized int type magic')
+                        log.warning(f'Parameter "{keyname}" is not int type magic comment')
+                else:
+                    keyname = _get_keyname(part)
+                    t = types.get(keyname, None)
+                    if t is bool:
+                        values[keyname] = True
+                    elif t is not None:
+                        log.warning(f'Parameter "{keyname}" is known, but {t} is not bool')
+                    else:
+                        log.warning(f'Parameter "{keyname}" is not known magic comment')
 
     return MagicCommentResult(**values)

--- a/rpmautospec/magic_comments.py
+++ b/rpmautospec/magic_comments.py
@@ -36,7 +36,7 @@ def parse_magic_comments(message: str) -> MagicCommentResult:
 
        [bump release: 3]
        [bump rightmost: 4]
-"""
+    """
 
     types = typing.get_type_hints(MagicCommentResult)
     values = dict()
@@ -52,8 +52,6 @@ def parse_magic_comments(message: str) -> MagicCommentResult:
                     if keyname in types and types[keyname] is int:
                         values[keyname] = int(br_match.group("value"))
                     else:
-                        raise ValueError(
-                            f"Parameter \"{keyname}\" is not recognized int type magic"
-                        )
+                        raise ValueError(f'Parameter "{keyname}" is not recognized int type magic')
 
     return MagicCommentResult(**values)

--- a/rpmautospec/magic_comments.py
+++ b/rpmautospec/magic_comments.py
@@ -1,26 +1,59 @@
 import re
-from typing import NamedTuple
+import typing
 
 magic_comment_re = re.compile(r"^\s*\[(?P<magic>.*)\]\s*$")
-skip_changelog_re = re.compile(r"\s*skip\s+changelog\s*")
-bump_release_re = re.compile(r"\s*bump\s+release\s*(?::\s*)?(?P<bump_value>\d+)\s*")
+intvalue_re = re.compile(r"\s*(?P<keyname>[a-z]+([\s_]+[a-z]+)*)\s*(?::\s*)?(?P<value>\d+)\s*")
 
 
-class MagicCommentResult(NamedTuple):
-    skip_changelog: bool
-    bump_release: int
+class MagicCommentResult(typing.NamedTuple):
+    """Stores special commit parameters extracted from a commit message."""
+
+    skip_changelog: bool = False
+    """Do not include this commit in changelog."""
+    start_rightmost: bool = False
+    """Start increasing number on the right of release string, not left."""
+    bump_release: int = 0
+    """Bump release to specified number."""
+    bump_rightmost: int = 0
+    """Bump rightmost (minorbump) of the release to specified number."""
 
 
 def parse_magic_comments(message: str) -> MagicCommentResult:
-    skip_changelog = False
-    bump_release = 0
+    """Parses commit message for special lines providing extra features.
+
+    Reworked to extract keywords from MagicCommentResult directly.
+    Should reduce code repetition and simplify documentation of supported keywords.
+
+    It does so by replacing spaces with _ underscore, then searching in defined
+    class properties. Do not define extra regex for everything.
+
+    Supports parsing of bool presences of:
+
+       [skip changelog]
+       [start rightmost]
+
+    Supports parsing of int values of:
+
+       [bump release: 3]
+       [bump rightmost: 4]
+"""
+
+    types = typing.get_type_hints(MagicCommentResult)
+    values = dict()
 
     for line in message.split("\n"):
         if l_match := magic_comment_re.match(line):
             for part in l_match.group("magic").split(","):
-                if skip_changelog_re.match(part):
-                    skip_changelog = True
-                if br_match := bump_release_re.match(part):
-                    bump_release = max(bump_release, int(br_match.group("bump_value")))
+                part = part.strip().replace(" ", "_")
+                if part in types and types[part] is bool:
+                    values[part] = True
+                elif br_match := intvalue_re.match(part):
+                    keyname = br_match.group("keyname")
+                    if keyname in types and types[keyname] is int:
+                        values[keyname] = int(br_match.group("value"))
+                    else:
+                        raise ValueError(
+                            f"Parameter \"{keyname}\" is not recognized int type magic"
+                        )
 
-    return MagicCommentResult(skip_changelog=skip_changelog, bump_release=bump_release)
+    return MagicCommentResult(**values)

--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -87,6 +87,7 @@ class PkgHistoryProcessor:
             self.repo = None
 
         self._rpmverflags_for_commits = {}
+        self.rightmost_bumps = False
 
     @staticmethod
     def _get_rpm_packager() -> str:
@@ -217,10 +218,13 @@ class PkgHistoryProcessor:
             base = verflags["base"]
             if base is None:
                 base = 1
+            right_base = verflags.get("right_base", 1)
+            if right_base is None:
+                right_base = 1
             tag_string = "".join(f".{t}" for t in (verflags["extraver"], verflags["snapinfo"]) if t)
         else:
             epoch_version = prerelease = None
-            base = 1
+            base = right_base = 1
             tag_string = ""
 
         if not epoch_version:
@@ -247,12 +251,21 @@ class PkgHistoryProcessor:
 
         commit_result["verflags"] = commit_verflags
         commit_result["epoch-version"] = epoch_version
-        commit_result["magic-comment-result"] = parse_magic_comments(commit.message)
+        magic_comments = parse_magic_comments(commit.message)
+        commit_result["magic-comment-result"] = magic_comments
+
+        if magic_comments.start_rightmost:
+            log.debug("\tstarting rightmost bumps")
+            self.rightmost_bumps = True
 
         log.debug("\tepoch_version: %s", epoch_version)
         log.debug(
             "\tparent rel numbers: %s",
             ", ".join(str(res["release-number"]) if res else "none" for res in parent_results),
+        )
+        log.debug(
+            "\tparent rightmost numbers: %s",
+            ", ".join(str(res["rightmost-number"]) if res else "none" for res in parent_results),
         )
 
         # Find the maximum applicable parent release number and increment by one if the
@@ -272,20 +285,51 @@ class PkgHistoryProcessor:
             )
             for res in parent_results
         )
+
         release_number = max(parent_release_numbers, default=0)
 
-        if self.specfile.name in commit.tree:
-            release_number += 1
+        parent_rightmost_numbers = tuple(
+            (
+                res["rightmost-number"]
+                if res
+                and (
+                    # Now increase rightmost only until epoch-version or release-number changes
+                    epoch_version is None
+                    or res["epoch-version"] is None
+                    or epoch_version == res["epoch-version"]
+                    or res["release-number"] == release_number
+                )
+                else 0
+            )
+            for res in parent_results
+        )
 
-        release_number = max(release_number, commit_result["magic-comment-result"].bump_release)
+        rightmost_number = max(parent_rightmost_numbers, default=0)
+
+        if self.specfile.name in commit.tree:
+            if self.rightmost_bumps:
+                rightmost_number += 1
+            else:
+                release_number += 1
+
+        release_number = max(release_number, magic_comments.bump_release)
+        rightmost_number = max(rightmost_number, magic_comments.bump_rightmost)
 
         commit_result["release-number"] = release_number
+        commit_result["rightmost-number"] = rightmost_number
 
-        log.debug("\trelease_number: %s", release_number)
+        log.debug("\trelease_number: %s (r%s)", release_number, rightmost_number)
 
         prerel_str = "0." if prerelease else ""
         release_number_with_base = release_number + base - 1
-        commit_result["release-complete"] = f"{prerel_str}{release_number_with_base}{tag_string}"
+        rightmost_with_base = rightmost_number + right_base - 1
+        rightmost_str = ""  # hide rightmost unless used
+        if rightmost_with_base > 0:
+            rightmost_str = "." + str(rightmost_with_base)
+
+        commit_result["release-complete"] = (
+            f"{prerel_str}{release_number_with_base}{tag_string}{rightmost_str}"
+        )
 
         yield commit_result
 

--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -105,7 +105,7 @@ class PkgHistoryProcessor:
             "extraver": None,
             "snapinfo": None,
             "base": 1,
-            "right_base": 0,
+            "rightmost-base": 0,
             "error": error,
             "error-detail": error_detail,
         }
@@ -195,7 +195,7 @@ class PkgHistoryProcessor:
                 specblob = commit.tree[self.specfile.name]
             except KeyError:
                 # no spec file
-                error = self._makerpmvererror("specfile-missing", "Spec file is missing.")
+                error = self._make_rpmvererror("specfile-missing", "Spec file is missing.")
                 self._rpmverflags_for_commits[commit] = error
                 return error
 
@@ -220,9 +220,9 @@ class PkgHistoryProcessor:
     def _get_release_complete(verflags, release_number, rightmost_number=0, tag_string=""):
         prerel_str = "0." if verflags["prerelease"] else ""
         base = verflags["base"] or 1
-        right_base = verflags.get("right_base", 1) or 1
+        rightmost_base = verflags.get("rightmost-base", 0) or 0
         release_number_with_base = release_number + base - 1
-        rightmost_with_base = rightmost_number + right_base - 1
+        rightmost_with_base = rightmost_number + rightmost_base
         rightmost_str = ""  # hide rightmost unless used
         if rightmost_with_base > 0:
             rightmost_str = "." + str(rightmost_with_base)

--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -97,6 +97,19 @@ class PkgHistoryProcessor:
         except Exception:
             return fallback
 
+    @staticmethod
+    def _make_rpmvererror(error, error_detail) -> dict[str, Union[str, int]]:
+        return {
+            "epoch-version": None,
+            "prerelease": False,
+            "extraver": None,
+            "snapinfo": None,
+            "base": 1,
+            "right_base": 0,
+            "error": error,
+            "error-detail": error_detail,
+        }
+
     def _get_rpmverflags(
         self, path: str, name: Optional[str] = None, log_error: bool = True
     ) -> dict[str, Union[str, int]]:
@@ -110,7 +123,7 @@ class PkgHistoryProcessor:
 
         if not specfile.exists():
             log.debug("spec file missing: %s", specfile)
-            return {"error": "specfile-missing", "error-detail": "Spec file is missing."}
+            return self._make_rpmvererror("specfile-missing", "Spec file is missing.")
 
         with (
             specfile.open(mode="rb") as unabridged,
@@ -145,7 +158,7 @@ class PkgHistoryProcessor:
         if error:
             if log_error:
                 log.debug("spec file query failed: %s", rpmerr_out)
-            return {"error": "specfile-parse-error", "error-detail": rpmerr_out}
+            return self._make_rpmvererror("specfile-parse-error", rpmerr_out)
 
         match = self.autorelease_flags_re.match(info)
         if match:
@@ -182,7 +195,7 @@ class PkgHistoryProcessor:
                 specblob = commit.tree[self.specfile.name]
             except KeyError:
                 # no spec file
-                error = {"error": "specfile-missing", "error-detail": "Spec file is missing."}
+                error = self._makerpmvererror("specfile-missing", "Spec file is missing.")
                 self._rpmverflags_for_commits[commit] = error
                 return error
 
@@ -199,6 +212,22 @@ class PkgHistoryProcessor:
         self._rpmverflags_for_commits[commit] = rpmverflags
         return rpmverflags
 
+    @staticmethod
+    def _get_tagstring(verflags):
+        return "".join(f".{t}" for t in (verflags["extraver"], verflags["snapinfo"]) if t)
+
+    @staticmethod
+    def _get_release_complete(verflags, release_number, rightmost_number=0, tag_string=""):
+        prerel_str = "0." if verflags["prerelease"] else ""
+        base = verflags["base"] or 1
+        right_base = verflags.get("right_base", 1) or 1
+        release_number_with_base = release_number + base - 1
+        rightmost_with_base = rightmost_number + right_base - 1
+        rightmost_str = ""  # hide rightmost unless used
+        if rightmost_with_base > 0:
+            rightmost_str = "." + str(rightmost_with_base)
+        return f"{prerel_str}{release_number_with_base}{tag_string}{rightmost_str}"
+
     def release_number_visitor(self, commit: pygit2.Commit, child_info: dict[str, Any]):
         """Visit a commit to determine its release number.
 
@@ -214,17 +243,9 @@ class PkgHistoryProcessor:
 
         if "error" not in verflags:
             epoch_version = verflags["epoch-version"]
-            prerelease = verflags["prerelease"]
-            base = verflags["base"]
-            if base is None:
-                base = 1
-            right_base = verflags.get("right_base", 1)
-            if right_base is None:
-                right_base = 1
-            tag_string = "".join(f".{t}" for t in (verflags["extraver"], verflags["snapinfo"]) if t)
+            tag_string = self._get_tagstring(verflags)
         else:
-            epoch_version = prerelease = None
-            base = right_base = 1
+            epoch_version = None
             tag_string = ""
 
         if not epoch_version:
@@ -254,7 +275,7 @@ class PkgHistoryProcessor:
         magic_comments = parse_magic_comments(commit.message)
         commit_result["magic-comment-result"] = magic_comments
 
-        if magic_comments.start_rightmost:
+        if magic_comments.start_rightmost or magic_comments.bump_rightmost > 0:
             log.debug("\tstarting rightmost bumps")
             self.rightmost_bumps = True
 
@@ -321,15 +342,8 @@ class PkgHistoryProcessor:
         log.debug("\trelease_number: %s", release_number)
         log.debug("\trightmost_number: %s", rightmost_number)
 
-        prerel_str = "0." if prerelease else ""
-        release_number_with_base = release_number + base - 1
-        rightmost_with_base = rightmost_number + right_base - 1
-        rightmost_str = ""  # hide rightmost unless used
-        if rightmost_with_base > 0:
-            rightmost_str = "." + str(rightmost_with_base)
-
-        commit_result["release-complete"] = (
-            f"{prerel_str}{release_number_with_base}{tag_string}{rightmost_str}"
+        commit_result["release-complete"] = self._get_release_complete(
+            verflags, release_number, rightmost_number, tag_string=tag_string
         )
 
         yield commit_result
@@ -744,15 +758,6 @@ class PkgHistoryProcessor:
             worktree_result = {}
 
             verflags = self._get_rpmverflags(self.path, name=self.name)
-            if "error" in verflags:
-                # cringe, but what can you do?
-                verflags |= {
-                    "epoch-version": None,
-                    "prerelease": False,
-                    "extraver": None,
-                    "snapinfo": None,
-                    "base": 1,
-                }
 
             # Mimic the bottom half of release_number_visitor
             worktree_result["verflags"] = verflags
@@ -763,14 +768,8 @@ class PkgHistoryProcessor:
                 release_number = 1
             worktree_result["release-number"] = release_number
 
-            prerel_str = "0." if verflags["prerelease"] else ""
-            tag_string = "".join(f".{t}" for t in (verflags["extraver"], verflags["snapinfo"]) if t)
-            base = verflags["base"]
-            if base is None:
-                base = 1
-            release_number_with_base = release_number + base - 1
-            worktree_result["release-complete"] = release_complete = (
-                f"{prerel_str}{release_number_with_base}{tag_string}"
+            worktree_result["release-complete"] = release_complete = self._get_release_complete(
+                verflags, release_number, tag_string=self._get_tagstring(verflags)
             )
 
             # Mimic the bottom half of the changelog visitor for a generic entry

--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -318,7 +318,8 @@ class PkgHistoryProcessor:
         commit_result["release-number"] = release_number
         commit_result["rightmost-number"] = rightmost_number
 
-        log.debug("\trelease_number: %s (r%s)", release_number, rightmost_number)
+        log.debug("\trelease_number: %s", release_number)
+        log.debug("\trightmost_number: %s", rightmost_number)
 
         prerel_str = "0." if prerelease else ""
         release_number_with_base = release_number + base - 1

--- a/rpmautospec/subcommands/process_distgit.py
+++ b/rpmautospec/subcommands/process_distgit.py
@@ -21,11 +21,17 @@ RPMAUTOSPEC_TEMPLATE = """## START: Set by rpmautospec
 """
 
 AUTORELEASE_TEMPLATE = """
-%define autorelease(e:s:pb:n) %{{?-p:0.}}%{{lua:
+%define autorelease(e:s:pb:r:n) %{{?-p:0.}}%{{lua:
     release_number = {autorelease_number:d};
     base_release_number = tonumber(rpm.expand("%{{?-b*}}%{{!?-b:1}}"));
     print(release_number + base_release_number - 1);
-}}%{{?-e:.%{{-e*}}}}%{{?-s:.%{{-s*}}}}%{{!?-n:%{{?dist}}}}"""  # noqa: E501
+}}%{{?-e:.%{{-e*}}}}%{{?-s:.%{{-s*}}}}%{{!?-n:%{{?dist}}}}%{{lua:
+    rightmost_number = {rightmost_number:d};
+    rightmost_base_number = tonumber(rpm.expand("%{{?-r*}}%{{!?-r:0}}"));
+    if ((rightmost_number + rightmost_base_number) > 0) then
+        string.format(".%d", rightmost_number + rightmost_base_number);
+    end;
+}}"""  # noqa: E501
 
 
 def do_process_distgit(
@@ -86,6 +92,7 @@ def do_process_distgit(
         )
 
     autorelease_number = result["release-number"]
+    rightmost_number = result["rightmost-number"]
 
     with (
         processor.specfile.open("r", encoding="utf-8", errors="surrogateescape") as specfile,
@@ -98,7 +105,8 @@ def do_process_distgit(
 
         if features.has_autorelease:
             autorelease_blurb_if_needed = AUTORELEASE_TEMPLATE.format(
-                autorelease_number=autorelease_number
+                autorelease_number=autorelease_number,
+                rightmost_number=rightmost_number,
             )
             used_features.append("autorelease")
         else:

--- a/rpmautospec/subcommands/process_distgit.py
+++ b/rpmautospec/subcommands/process_distgit.py
@@ -29,7 +29,7 @@ AUTORELEASE_TEMPLATE = """
     rightmost_number = {rightmost_number:d};
     rightmost_base_number = tonumber(rpm.expand("%{{?-r*}}%{{!?-r:0}}"));
     if ((rightmost_number + rightmost_base_number) > 0) then
-        string.format(".%d", rightmost_number + rightmost_base_number);
+        print(string.format(".%d", rightmost_number + rightmost_base_number));
     end;
 }}"""  # noqa: E501
 
@@ -92,7 +92,7 @@ def do_process_distgit(
         )
 
     autorelease_number = result["release-number"]
-    rightmost_number = result["rightmost-number"]
+    rightmost_number = result.get("rightmost-number", 0)
 
     with (
         processor.specfile.open("r", encoding="utf-8", errors="surrogateescape") as specfile,

--- a/tests/rpmautospec/subcommands/test_process_distgit.py
+++ b/tests/rpmautospec/subcommands/test_process_distgit.py
@@ -94,7 +94,10 @@ def fuzz_spec_file(
         new_spec_file_path.open("w", encoding="utf-8") as new,
     ):
         if is_processed:
-            autorelease_blurb = process_distgit.AUTORELEASE_TEMPLATE.format(autorelease_number=15)
+            autorelease_blurb = process_distgit.AUTORELEASE_TEMPLATE.format(
+                autorelease_number=15,
+                rightmost_number=0,
+            )
             print(
                 process_distgit.RPMAUTOSPEC_TEMPLATE.format(
                     version=__version__,

--- a/tests/rpmautospec/test_magic_comments.py
+++ b/tests/rpmautospec/test_magic_comments.py
@@ -1,5 +1,6 @@
 import re
 from pathlib import Path
+from typing import get_type_hints
 
 import pytest
 import yaml
@@ -13,20 +14,20 @@ COMMITLOGFILE_RE = re.compile(r"^commit-(?P<variant>.*)\.txt$")
 
 def _read_commitlog_magic_comments_testdata():
     parametrized = []
+    magic_types = get_type_hints(MagicCommentResult)
+
     for commitlog_path in sorted(COMMITLOG_CHANGELOG_DIR.glob("commit*.txt")):
         match = COMMITLOGFILE_RE.match(commitlog_path.name)
         variant = match.group("variant")
         chlog_items_path = commitlog_path.with_name(f"expected-{variant}.yaml")
         with open(chlog_items_path, "r") as chlog_items_fp:
             d = yaml.safe_load(chlog_items_fp)
+            magics = {k: d[k] for k in d if k in magic_types}
 
         parametrized.append(
             pytest.param(
                 commitlog_path.read_text(),
-                MagicCommentResult(
-                    skip_changelog=d.get("skip_changelog", False),
-                    bump_release=d.get("bump_release", 0),
-                ),
+                MagicCommentResult(**magics),
                 id=f"commit-{variant}",
             )
         )

--- a/tests/rpmautospec/test_magic_comments.py
+++ b/tests/rpmautospec/test_magic_comments.py
@@ -1,5 +1,6 @@
 import re
 from pathlib import Path
+from typing import get_type_hints
 
 import pytest
 import yaml
@@ -13,6 +14,8 @@ COMMITLOGFILE_RE = re.compile(r"^commit-(?P<variant>.*)\.txt$")
 
 def _read_commitlog_magic_comments_testdata():
     parametrized = []
+    magic_types = get_type_hints(MagicCommentResult)
+
     for commitlog_path in sorted(COMMITLOG_CHANGELOG_DIR.glob("commit*.txt")):
         match = COMMITLOGFILE_RE.match(commitlog_path.name)
         variant = match.group("variant")
@@ -20,13 +23,14 @@ def _read_commitlog_magic_comments_testdata():
         with open(chlog_items_path, "r") as chlog_items_fp:
             d = yaml.safe_load(chlog_items_fp)
 
+        for k in d:
+            if k not in magic_types:
+                d.pop(k, None)
+
         parametrized.append(
             pytest.param(
                 commitlog_path.read_text(),
-                MagicCommentResult(
-                    skip_changelog=d.get("skip_changelog", False),
-                    bump_release=d.get("bump_release", 0),
-                ),
+                MagicCommentResult(**d),
                 id=f"commit-{variant}",
             )
         )

--- a/tests/rpmautospec/test_magic_comments.py
+++ b/tests/rpmautospec/test_magic_comments.py
@@ -22,15 +22,12 @@ def _read_commitlog_magic_comments_testdata():
         chlog_items_path = commitlog_path.with_name(f"expected-{variant}.yaml")
         with open(chlog_items_path, "r") as chlog_items_fp:
             d = yaml.safe_load(chlog_items_fp)
-
-        for k in d:
-            if k not in magic_types:
-                d.pop(k, None)
+            magics = {k: d[k] for k in d if k in magic_types}
 
         parametrized.append(
             pytest.param(
                 commitlog_path.read_text(),
-                MagicCommentResult(**d),
+                MagicCommentResult(**magics),
                 id=f"commit-{variant}",
             )
         )

--- a/tests/test-data/commitlogs/commit-5.txt
+++ b/tests/test-data/commitlogs/commit-5.txt
@@ -1,0 +1,9 @@
+The subject
+
+...continues here. And it continues
+even further.
+
+Here's more detail, but it should be ignored.
+Test rpmdev-bumpspec -r variant.
+
+[bump rightmost: 2]

--- a/tests/test-data/commitlogs/commit-6.txt
+++ b/tests/test-data/commitlogs/commit-6.txt
@@ -1,0 +1,8 @@
+Check unknown magic strings
+
+...do not break the parser.
+
+Ensure we are forward-compatible
+
+[bump nonexistent: 2]
+[anybool]

--- a/tests/test-data/commitlogs/commit-7.txt
+++ b/tests/test-data/commitlogs/commit-7.txt
@@ -1,0 +1,5 @@
+Check rightmost bump start is handled
+
+Do minor bumps from now forward.
+
+[start rightmost]

--- a/tests/test-data/commitlogs/expected-5.txt
+++ b/tests/test-data/commitlogs/expected-5.txt
@@ -1,0 +1,1 @@
+- The subject continues here. And it continues even further.

--- a/tests/test-data/commitlogs/expected-5.yaml
+++ b/tests/test-data/commitlogs/expected-5.yaml
@@ -1,0 +1,4 @@
+---
+changelog_items:
+  - The subject continues here. And it continues even further.
+bump_rightmost: 2

--- a/tests/test-data/commitlogs/expected-6.txt
+++ b/tests/test-data/commitlogs/expected-6.txt
@@ -1,0 +1,1 @@
+- Check unknown magic strings do not break the parser.

--- a/tests/test-data/commitlogs/expected-6.yaml
+++ b/tests/test-data/commitlogs/expected-6.yaml
@@ -1,0 +1,3 @@
+---
+changelog_items:
+  - Check unknown magic strings do not break the parser.

--- a/tests/test-data/commitlogs/expected-7.txt
+++ b/tests/test-data/commitlogs/expected-7.txt
@@ -1,0 +1,1 @@
+- Check rightmost bump start is handled.

--- a/tests/test-data/commitlogs/expected-7.txt
+++ b/tests/test-data/commitlogs/expected-7.txt
@@ -1,1 +1,1 @@
-- Check rightmost bump start is handled.
+- Check rightmost bump start is handled

--- a/tests/test-data/commitlogs/expected-7.txt
+++ b/tests/test-data/commitlogs/expected-7.txt
@@ -1,0 +1,1 @@
+- Check rightmost bump start is handled

--- a/tests/test-data/commitlogs/expected-7.yaml
+++ b/tests/test-data/commitlogs/expected-7.yaml
@@ -1,4 +1,4 @@
 ---
 changelog_items:
-  - Check rightmost bump start is handled.
+  - Check rightmost bump start is handled
 start_rightmost: true

--- a/tests/test-data/commitlogs/expected-7.yaml
+++ b/tests/test-data/commitlogs/expected-7.yaml
@@ -1,0 +1,4 @@
+---
+changelog_items:
+  - Check rightmost bump start is handled
+start_rightmost: true

--- a/tests/test-data/commitlogs/expected-7.yaml
+++ b/tests/test-data/commitlogs/expected-7.yaml
@@ -1,0 +1,4 @@
+---
+changelog_items:
+  - Check rightmost bump start is handled.
+start_rightmost: true


### PR DESCRIPTION
Adds new magic comments supported in commits:

[bump_rightmost: 3]
[start_rightmost]

This should implement missing z-stream type bumps used mainly in RHEL already released branches fixes.

It is needed to ensure latest branch build is always preferred after upgrade to higher version. In Fedora regular mass rebuilds mitigates the need for something similar. But it could be still used when doing rebase in multiple branches, where only rawhide build should always have highest release.