### PR TITLE
Include documentation in source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,10 @@ include = [
     "tests/test-data/repodata/dummy-test-package-gloster-git.tar.gz",
     "tests/test-data/repodata/dummy-test-package-gloster.spec.expected",
     "tests/test-data/test-specfiles/*.spec",
+    "doc/Makefile",
+    "doc/conf.py",
+    "doc/*.rst",
+    "doc/_static/*",
     "tox.ini",
 ]
 


### PR DESCRIPTION
%autorelease is currently not documented at all by the binary distribution package. Because source archive does not contain it, it cannot be added into the source package.

Include documentation in source archive to add it later into binary package(s) too.