### PR TITLE
Support pygit2 >= 1.20 (mostly)

### DIFF
--- a/rpmautospec/_wrappers/minigit2/__init__.py
+++ b/rpmautospec/_wrappers/minigit2/__init__.py
@@ -1,8 +1,7 @@
 """Minimal wrapper for libgit2
 
 This package wraps the functionality of libgit2 used by rpmautospec (and
-only that), aiming to mimic the pygit2 API (of the minimum version
-supported, 1.1).
+only that), aiming to mimic the pygit2 API (of version 1.20).
 
 The reason we want to be able to bypass pygit2 itself is because it
 makes bootstrapping rpmautospec hairy (e.g. for a new Python version).
@@ -11,28 +10,6 @@ makes bootstrapping rpmautospec hairy (e.g. for a new Python version).
 from . import enums, settings
 from .blob import Blob
 from .commit import Commit
-from .constants import (
-    GIT_CHECKOUT_FORCE,
-    GIT_CONFIG_LEVEL_GLOBAL,
-    GIT_CONFIG_LEVEL_LOCAL,
-    GIT_CONFIG_LEVEL_SYSTEM,
-    GIT_CONFIG_LEVEL_XDG,
-    GIT_REPOSITORY_OPEN_NO_SEARCH,
-    GIT_STATUS_CONFLICTED,
-    GIT_STATUS_CURRENT,
-    GIT_STATUS_IGNORED,
-    GIT_STATUS_INDEX_DELETED,
-    GIT_STATUS_INDEX_MODIFIED,
-    GIT_STATUS_INDEX_NEW,
-    GIT_STATUS_INDEX_RENAMED,
-    GIT_STATUS_INDEX_TYPECHANGE,
-    GIT_STATUS_WT_DELETED,
-    GIT_STATUS_WT_MODIFIED,
-    GIT_STATUS_WT_NEW,
-    GIT_STATUS_WT_RENAMED,
-    GIT_STATUS_WT_TYPECHANGE,
-    GIT_STATUS_WT_UNREADABLE,
-)
 from .exc import GitError
 from .oid import Oid
 from .repository import Repository

--- a/rpmautospec/_wrappers/minigit2/constants.py
+++ b/rpmautospec/_wrappers/minigit2/constants.py
@@ -1,40 +1,15 @@
 from . import native_adaptation
 
-GIT_CHECKOUT_FORCE = native_adaptation.git_checkout_strategy_t.FORCE
 GIT_CHECKOUT_OPTIONS_VERSION = 1
-
-GIT_CONFIG_LEVEL_SYSTEM = native_adaptation.git_config_level_t.SYSTEM
-GIT_CONFIG_LEVEL_XDG = native_adaptation.git_config_level_t.XDG
-GIT_CONFIG_LEVEL_GLOBAL = native_adaptation.git_config_level_t.GLOBAL
-GIT_CONFIG_LEVEL_LOCAL = native_adaptation.git_config_level_t.LOCAL
-
 GIT_DIFF_OPTIONS_VERSION = 1
+GIT_REPOSITORY_INIT_OPTIONS_VERSION = 1
+GIT_STATUS_OPTIONS_VERSION = 1
 
 GIT_OID_RAWSZ = GIT_OID_SHA1_SIZE = 20
 GIT_OID_HEXSZ = GIT_OID_SHA1_HEXSIZE = GIT_OID_SHA1_SIZE * 2
-
-GIT_REPOSITORY_INIT_OPTIONS_VERSION = 1
-GIT_REPOSITORY_OPEN_NO_SEARCH = native_adaptation.git_repository_open_flag_t.NO_SEARCH
-
-GIT_STATUS_CURRENT = native_adaptation.git_status_t.CURRENT
-GIT_STATUS_INDEX_NEW = native_adaptation.git_status_t.INDEX_NEW
-GIT_STATUS_INDEX_MODIFIED = native_adaptation.git_status_t.INDEX_MODIFIED
-GIT_STATUS_INDEX_DELETED = native_adaptation.git_status_t.INDEX_DELETED
-GIT_STATUS_INDEX_RENAMED = native_adaptation.git_status_t.INDEX_RENAMED
-GIT_STATUS_INDEX_TYPECHANGE = native_adaptation.git_status_t.INDEX_TYPECHANGE
-GIT_STATUS_WT_NEW = native_adaptation.git_status_t.WT_NEW
-GIT_STATUS_WT_MODIFIED = native_adaptation.git_status_t.WT_MODIFIED
-GIT_STATUS_WT_DELETED = native_adaptation.git_status_t.WT_DELETED
-GIT_STATUS_WT_TYPECHANGE = native_adaptation.git_status_t.WT_TYPECHANGE
-GIT_STATUS_WT_RENAMED = native_adaptation.git_status_t.WT_RENAMED
-GIT_STATUS_WT_UNREADABLE = native_adaptation.git_status_t.WT_UNREADABLE
-GIT_STATUS_IGNORED = native_adaptation.git_status_t.IGNORED
-GIT_STATUS_CONFLICTED = native_adaptation.git_status_t.CONFLICTED
 
 GIT_STATUS_OPT_DEFAULTS = (
     native_adaptation.git_status_opt_t.INCLUDE_IGNORED
     | native_adaptation.git_status_opt_t.INCLUDE_UNTRACKED
     | native_adaptation.git_status_opt_t.RECURSE_UNTRACKED_DIRS
 )
-
-GIT_STATUS_OPTIONS_VERSION = 1

--- a/rpmautospec/_wrappers/minigit2/enums.py
+++ b/rpmautospec/_wrappers/minigit2/enums.py
@@ -1,2 +1,42 @@
-from .native_adaptation import git_delta_t as DeltaStatus  # noqa: F401
-from .native_adaptation import git_diff_flag_t as DiffFlag  # noqa: F401
+from enum import IntEnum, IntFlag
+
+from . import native_adaptation
+
+DeltaStatus = native_adaptation.git_delta_t
+DiffFlag = native_adaptation.git_diff_flag_t
+
+
+# The following are monkey-patched in rpmautospec.compat if old pygit2 versions are present. If
+# anything is added here, it needs to be added there as well.
+
+
+class CheckoutStrategy(IntFlag):
+    FORCE = native_adaptation.git_checkout_strategy_t.FORCE
+
+
+class ConfigLevel(IntEnum):
+    SYSTEM = native_adaptation.git_config_level_t.SYSTEM
+    XDG = native_adaptation.git_config_level_t.XDG
+    GLOBAL = native_adaptation.git_config_level_t.GLOBAL
+    LOCAL = native_adaptation.git_config_level_t.LOCAL
+
+
+class FileStatus(IntFlag):
+    CURRENT = native_adaptation.git_status_t.CURRENT
+    INDEX_NEW = native_adaptation.git_status_t.INDEX_NEW
+    INDEX_MODIFIED = native_adaptation.git_status_t.INDEX_MODIFIED
+    INDEX_DELETED = native_adaptation.git_status_t.INDEX_DELETED
+    INDEX_RENAMED = native_adaptation.git_status_t.INDEX_RENAMED
+    INDEX_TYPECHANGE = native_adaptation.git_status_t.INDEX_TYPECHANGE
+    WT_NEW = native_adaptation.git_status_t.WT_NEW
+    WT_MODIFIED = native_adaptation.git_status_t.WT_MODIFIED
+    WT_DELETED = native_adaptation.git_status_t.WT_DELETED
+    WT_TYPECHANGE = native_adaptation.git_status_t.WT_TYPECHANGE
+    WT_RENAMED = native_adaptation.git_status_t.WT_RENAMED
+    WT_UNREADABLE = native_adaptation.git_status_t.WT_UNREADABLE
+    IGNORED = native_adaptation.git_status_t.IGNORED
+    CONFLICTED = native_adaptation.git_status_t.CONFLICTED
+
+
+class RepositoryOpenFlag(IntFlag):
+    NO_SEARCH = native_adaptation.git_repository_open_flag_t.NO_SEARCH

--- a/rpmautospec/compat.py
+++ b/rpmautospec/compat.py
@@ -1,5 +1,8 @@
+from enum import IntEnum, IntFlag
 from io import BytesIO
 from typing import TYPE_CHECKING
+
+needs_minimal_pygit2_enums = False
 
 try:
     import pygit2
@@ -9,6 +12,16 @@ except ImportError:  # pragma: has-no-pygit2
     uses_minigit2 = True
 else:  # pragma: has-pygit2
     uses_minigit2 = False
+
+    # The pygit2.enums module was introduced partly in 1.13.3 and fully in 1.14.0. Attempt to import
+    # the used enum types, so we can monkey-patch them if necessary.
+    try:
+        from pygit2.enums import CheckoutStrategy, ConfigLevel, FileStatus, RepositoryOpenFlag
+    except ImportError:  # pragma: no cover
+        needs_minimal_pygit2_enums = True
+    else:  # pragma: no cover
+        del CheckoutStrategy, ConfigLevel, FileStatus, RepositoryOpenFlag
+
 
 needs_minimal_blobio = False
 if uses_minigit2:  # pragma: has-no-pygit2
@@ -23,6 +36,44 @@ try:
     import rpm
 except ImportError:  # pragma: has-no-rpm
     from ._wrappers import minirpm as rpm  # noqa: F401
+
+
+# This is only for pygit2 < 1.14, so ignore it for coverage.
+if not uses_minigit2 and needs_minimal_pygit2_enums:  # pragma: no cover
+
+    class _pygit2_enums:
+        # Wrap old names in enum classes. See minigit2.enums for which enum types/values are needed.
+
+        class CheckoutStrategy(IntFlag):
+            FORCE = pygit2.GIT_CHECKOUT_FORCE
+
+        class ConfigLevel(IntEnum):
+            SYSTEM = pygit2.GIT_CONFIG_LEVEL_SYSTEM
+            XDG = pygit2.GIT_CONFIG_LEVEL_XDG
+            GLOBAL = pygit2.GIT_CONFIG_LEVEL_GLOBAL
+            LOCAL = pygit2.GIT_CONFIG_LEVEL_LOCAL
+
+        class FileStatus(IntFlag):
+            CURRENT = pygit2.GIT_STATUS_CURRENT
+            INDEX_NEW = pygit2.GIT_STATUS_INDEX_NEW
+            INDEX_MODIFIED = pygit2.GIT_STATUS_INDEX_MODIFIED
+            INDEX_DELETED = pygit2.GIT_STATUS_INDEX_DELETED
+            INDEX_RENAMED = pygit2.GIT_STATUS_INDEX_RENAMED
+            INDEX_TYPECHANGE = pygit2.GIT_STATUS_INDEX_TYPECHANGE
+            WT_NEW = pygit2.GIT_STATUS_WT_NEW
+            WT_MODIFIED = pygit2.GIT_STATUS_WT_MODIFIED
+            WT_DELETED = pygit2.GIT_STATUS_WT_DELETED
+            WT_TYPECHANGE = pygit2.GIT_STATUS_WT_TYPECHANGE
+            WT_RENAMED = pygit2.GIT_STATUS_WT_RENAMED
+            WT_UNREADABLE = pygit2.GIT_STATUS_WT_UNREADABLE
+            IGNORED = pygit2.GIT_STATUS_IGNORED
+            CONFLICTED = pygit2.GIT_STATUS_CONFLICTED
+
+        class RepositoryOpenFlag(IntFlag):
+            NO_SEARCH = pygit2.GIT_REPOSITORY_OPEN_NO_SEARCH
+
+    pygit2.enums = _pygit2_enums
+
 
 if TYPE_CHECKING:
     if uses_minigit2:

--- a/rpmautospec/pkg_history.py
+++ b/rpmautospec/pkg_history.py
@@ -82,7 +82,9 @@ class PkgHistoryProcessor:
             raise FileNotFoundError(f"Spec file '{self.specfile}' doesn't exist in '{self.path}'.")
 
         try:
-            self.repo = pygit2.Repository(self.path, flags=pygit2.GIT_REPOSITORY_OPEN_NO_SEARCH)
+            self.repo = pygit2.Repository(
+                self.path, flags=pygit2.enums.RepositoryOpenFlag.NO_SEARCH
+            )
         except pygit2.GitError:
             self.repo = None
 

--- a/rpmautospec/subcommands/convert.py
+++ b/rpmautospec/subcommands/convert.py
@@ -53,7 +53,9 @@ class PkgConverter:
         log.debug("Working on spec file %s", self.specfile)
 
         try:
-            self.repo = pygit2.Repository(self.path, flags=pygit2.GIT_REPOSITORY_OPEN_NO_SEARCH)
+            self.repo = pygit2.Repository(
+                self.path, flags=pygit2.enums.RepositoryOpenFlag.NO_SEARCH
+            )
             log.debug("Found repository at %s", self.path)
         except pygit2.GitError:
             self.repo = None
@@ -62,12 +64,15 @@ class PkgConverter:
         if self.repo is not None:
             spec_status = self.repo.status_file(self.specfile.relative_to(self.path))
 
-            if spec_status == pygit2.GIT_STATUS_WT_NEW:
+            if spec_status == pygit2.enums.FileStatus.WT_NEW:
                 raise FileUntrackedError(
                     f"Spec file '{self.specfile}' exists in the repository, but is untracked"
                 )
             # Allow converting unmodified, and saved-to-index files.
-            if spec_status not in (pygit2.GIT_STATUS_CURRENT, pygit2.GIT_STATUS_INDEX_MODIFIED):
+            if spec_status not in (
+                pygit2.enums.FileStatus.CURRENT,
+                pygit2.enums.FileStatus.INDEX_MODIFIED,
+            ):
                 raise FileModifiedError(f"Spec file '{self.specfile}' is modified")
             try:
                 self.repo.status_file("changelog")
@@ -77,9 +82,9 @@ class PkgConverter:
                 raise FileExistsError("Changelog file 'changelog' is already in the repository")
             for filepath, flags in self.repo.status().items():
                 if flags not in (
-                    pygit2.GIT_STATUS_CURRENT,
-                    pygit2.GIT_STATUS_IGNORED,
-                    pygit2.GIT_STATUS_WT_NEW,
+                    pygit2.enums.FileStatus.CURRENT,
+                    pygit2.enums.FileStatus.IGNORED,
+                    pygit2.enums.FileStatus.WT_NEW,
                 ):
                     raise FileModifiedError(f"Repository '{self.path}' is dirty")
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -84,7 +84,7 @@ def create_commit(
     if create_branch is not _UNSET:
         repo.create_branch(create_branch or "rawhide", commit)
 
-    repo.checkout_tree(commit.tree, strategy=pygit2.GIT_CHECKOUT_FORCE)
+    repo.checkout_tree(commit.tree, strategy=pygit2.enums.CheckoutStrategy.FORCE)
 
     return {"oid": oid, "commit": commit}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,10 @@ def git_empty_config(tmp_path: Path):
     """Ensure tests run with empty git configuration."""
     for impl in PYGIT2_IMPLEMENTATIONS:
         for level in (
-            impl.GIT_CONFIG_LEVEL_SYSTEM,
-            impl.GIT_CONFIG_LEVEL_XDG,
-            impl.GIT_CONFIG_LEVEL_GLOBAL,
-            impl.GIT_CONFIG_LEVEL_LOCAL,
+            impl.enums.ConfigLevel.SYSTEM,
+            impl.enums.ConfigLevel.XDG,
+            impl.enums.ConfigLevel.GLOBAL,
+            impl.enums.ConfigLevel.LOCAL,
         ):
             try:
                 impl.settings.search_path[level] = "/dev/null"
@@ -191,7 +191,7 @@ def repo(repopath, specfile, specfile_content, _repo_config):
     add_commit = _repo_config["add_commit"]
 
     pygit2.init_repository(repopath, initial_head="rawhide")
-    repo = pygit2.Repository(repopath, pygit2.GIT_REPOSITORY_OPEN_NO_SEARCH)
+    repo = pygit2.Repository(repopath, pygit2.enums.RepositoryOpenFlag.NO_SEARCH)
 
     repo.config["user.name"] = "Jane Doe"
     repo.config["user.email"] = "jane.doe@example.com"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from rpmautospec.compat import pygit2
 from .common import SPEC_FILE_TEMPLATE, create_commit
 
 PYGIT2_IMPLEMENTATIONS = [pygit2]
-if pygit2 != minigit2:
+if pygit2 is not minigit2:
     PYGIT2_IMPLEMENTATIONS.append(minigit2)
 
 

--- a/tests/rpmautospec/subcommands/test_convert.py
+++ b/tests/rpmautospec/subcommands/test_convert.py
@@ -305,7 +305,7 @@ def test_commit(specfile, release, changelog, repo):
     converter.commit("Convert to rpmautospec.")
 
     for filepath, flags in repo.status().items():
-        assert flags == pygit2.GIT_STATUS_CURRENT
+        assert flags == pygit2.enums.FileStatus.CURRENT
 
     changelog_should_change = autochangelog_re.search(changelog) is None
     release_should_change = autorelease_re.search(release) is None


### PR DESCRIPTION
commit 869ecce3e325c0e4466a6ce8aa297b68e60e5405
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Aug 20 16:05:31 2026 +0200

    Check if pygit2 is minigit2 by identity
    
    Apparently, the "==" operator isn’t supported for module objects (even
    though it seems to have worked so far).
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit c87e1becd4532810987aec938c6ab6012e420077
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Aug 20 16:11:31 2026 +0200

    Support pygit2 >= 1.20
    
    Use the pygit2.enums module where applicable, extend it in minigit2 to
    the extent necessary and monkey-patch the used enums if encountering old
    pygit2 versions (<1.14) that don’t have them yet.
    
    Fixes: #417
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>